### PR TITLE
Sort resources by published date

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -1273,6 +1273,7 @@ class ResourceController extends Controller
             $rs->save();
         }else{
             $rs->status = 1;
+            $rs->published_at = date('Y-m-d H:i:s');
             $rs->save();   
         }
 

--- a/app/Resource.php
+++ b/app/Resource.php
@@ -385,7 +385,7 @@ class Resource extends Model
             })
             ->where('rs.language', Config::get('app.locale'))
             ->where('rs.status', 1)
-            ->orderBy('rs.created_at','desc')
+            ->orderBy('rs.published_at','desc')
             ->groupBy(
                 'rs.id',
                 'rs.language', 

--- a/database/migrations/2021_01_17_045707_add_published_at_to_resources.php
+++ b/database/migrations/2021_01_17_045707_add_published_at_to_resources.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPublishedAtToResources extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+    }
+}


### PR DESCRIPTION
Right now, when we publish a submitted resource it will show up on DDL on the date of submission. It is required to sort resources library based on the published date.