### PR TITLE
Ddl fix sign up spell issues

### DIFF
--- a/resources/lang/fa.json
+++ b/resources/lang/fa.json
@@ -169,7 +169,7 @@
     "Email or username or phone": "ایمیل یا نام کاربری یا شماره تیلفون",
     "Favorite this item": "این موضوع را در مجموعه «مورد علاقه« اضافه کنید",
     "Favorite this resource": "این مطلب را در «مورد علاقه» اضافه کنید",
-    "First name": "نام خانواده‌گی",
+    "First name": "نام",
     "Forgot password?": "گذرواژه خود را فراموش کرده‌اید؟",
     "Home": "خانه",
     "In order to favorite a resource, you are required to": "برای این که یک منبع را به «مورد علاقه» اضافه کنید، باید",

--- a/resources/lang/fa.json
+++ b/resources/lang/fa.json
@@ -146,7 +146,7 @@
     "Want to schedule a demo of the DD Library at your school, college or institution? Send us a request using the contact form on this page.": "اگر میخواهید کتابخانه درخت دانش در نهاد تحصیلی شما معرفی شود، با پر کردن این فارم، درخواست خود را بفرستید.",
     "We received your message and will contact you back soon!": "پیام شما را دریافت کردیم و به زودی با شما تماس می گیریم!",
     "Prefer not to say": "ترجیح میدهم نگویم",
-    "Confirm password": "رمز ورود را تأیید کنید",
+    "Confirm password": "گذرواژه را تأیید کنید",
     "Want to receive our newsletter?": "آیا می‌خواهید خبرنامه برقی ما را به دست بیاورید؟",
     "About three times a year we send out the DDL newsletter. If you are a registered user of the Library, you will automatically receive the newsletter. If you are not a registered library user but would like to subscribe to our newsletter, please": "ما در یک سال در حدود سه خبرنامه کتاب‌خانه درخت دانش را به نشر می‌رسانیم. اگر شما در کتاب‌خانه درخت دانش ثبت نام کرده‌اید، خبرنامه کتاب‌خانه به صورت اتومات به شما ارسال می‌گردد. اگر عضو ثبت شده کتاب‌خانه درخت دانش نیستید و می‌خواهید خبرنامه برقی ما را به دست بیاورید؛ لطفاً اینجا کلیک کنید:\nhttps:\/\/darakhtdanesh.us11.list-manage.com\/subscribe?u=abbdaa95e801980b608399770&id=9bf90f679d",
     "405 Not Allowed": "اجازه نیست",


### PR DESCRIPTION
Two translation issues in sign up

1. we have two different translation words for password `رمز ورود` and `گذرواژه`
2. we display last_name for both `Name` and `Last Name`

![image](https://github.com/ddlibrary/ddlibrary/assets/18898699/0c73dde4-bd18-4a4a-85ae-f567c7871557)
