### PR TITLE
Add a language filter to the resource filter page

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -206,7 +206,9 @@ class ResourceController extends Controller
             ->resourceAttributesList('taxonomy_term_data', 13)
             ->where('parent', 0); // 13 being resource literacy levels
 
-        return view('resources.resources_filter', compact('parentSubjects', 'resourceTypes', 'literacyLevels'));
+        $languages = $this->getLanguages();
+
+        return view('resources.resources_filter', compact('parentSubjects', 'resourceTypes', 'literacyLevels', 'languages'));
     }
 
     public function getSubjectChildren(Request $request): array

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -326,7 +326,9 @@ class Resource extends Model
                     ->leftJoin('resource_publishers AS rpub', 'rpub.resource_id', '=', 'rs.id')
                     ->where('rpub.tid', $request['publisher']);
             })
-            ->where('rs.language', config('app.locale'))
+            ->when($request->input('language'), function($query) use ($request){
+               return $query->where('rs.language', $request->input('language'));
+            })
             ->where('rs.status', 1)
             ->where(function ($query) {
                 $query->where('rs.id', '>=', 11479)->orWhere('rs.id', '<', 10378); // TODO: remove after restoration

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -326,9 +326,15 @@ class Resource extends Model
                     ->leftJoin('resource_publishers AS rpub', 'rpub.resource_id', '=', 'rs.id')
                     ->where('rpub.tid', $request['publisher']);
             })
-            ->when($request->input('language'), function($query) use ($request){
-               return $query->where('rs.language', $request->input('language'));
-            })
+            ->when(
+                $request->has('language'),
+                fn ($q) => $q->when(
+                    $request->filled('language') && $request->input('language') != 'all',
+                    fn ($q2) => $q2->where('rs.language', $request->input('language')),
+                    fn ($q2) => $q2
+                ),
+                fn ($q) => $q->where('rs.language', config('app.locale'))
+            )
             ->where('rs.status', 1)
             ->where(function ($query) {
                 $query->where('rs.id', '>=', 11479)->orWhere('rs.id', '<', 10378); // TODO: remove after restoration

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -328,12 +328,17 @@ class Resource extends Model
             })
             ->when(
                 $request->has('language'),
-                fn ($q) => $q->when(
-                    $request->filled('language') && $request->input('language') != 'all',
-                    fn ($q2) => $q2->where('rs.language', $request->input('language')),
-                    fn ($q2) => $q2
-                ),
-                fn ($q) => $q->where('rs.language', config('app.locale'))
+                function ($query) use ($request) {
+                    return $query->when(
+                        $request->filled('language') && $request->input('language') !== 'all',
+                        function ($query) use ($request) {
+                            return $query->where('rs.language', $request->input('language'));
+                        }
+                    );
+                },
+                function ($query) {
+                    return $query->where('rs.language', config('app.locale'));
+                }
             )
             ->where('rs.status', 1)
             ->where(function ($query) {

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -327,14 +327,9 @@ class Resource extends Model
                     ->where('rpub.tid', $request['publisher']);
             })
             ->when(
-                $request->has('language'),
+                $request->filled('language'),
                 function ($query) use ($request) {
-                    return $query->when(
-                        $request->filled('language') && $request->input('language') !== 'all',
-                        function ($query) use ($request) {
-                            return $query->where('rs.language', $request->input('language'));
-                        }
-                    );
+                    return $query->whereIn('rs.language', $request['language']);
                 },
                 function ($query) {
                     return $query->where('rs.language', config('app.locale'));

--- a/resources/views/resources/resources_filter.blade.php
+++ b/resources/views/resources/resources_filter.blade.php
@@ -73,9 +73,9 @@
             <div class="form-item col-12 col-md-6 my-3 ">
                 <label for="search">@lang('Language')</label>
                 <select name="language" class="form-control">
-                    <option value="">...</option>
+                    <option value="all" @selected(request('language') === 'all')>...</option>
                     @foreach($languages as $index => $language)
-                        <option value="{{ $index }}" @selected($index == config('app.locale'))>{{ $language['native']}}</option>
+                        <option value="{{ $index }}" @selected($index == config('app.locale') && request('language') !== 'all')>{{ $language['native']}}</option>
                     @endforeach
                 </select>
             </div>

--- a/resources/views/resources/resources_filter.blade.php
+++ b/resources/views/resources/resources_filter.blade.php
@@ -66,9 +66,18 @@
                     @endforeach
                 </select>
             </div>
-            <div class="form-item col-6 my-3 {{ (Lang::locale() != 'en') ? 'ms-auto' : 'me-auto' }}">
-                <label for="search" class="sr-only">@lang('Keywords')</label>
+            <div class="form-item col-12 col-md-6 my-3 {{ (Lang::locale() != 'en') ? 'ms-auto' : 'me-auto' }}">
+                <label for="search">@lang('Keywords')</label>
                 <input type="text" name="search" class="form-control" placeholder="@lang('Keywords to filter by')">
+            </div>
+            <div class="form-item col-12 col-md-6 my-3 ">
+                <label for="search">@lang('Language')</label>
+                <select name="language" class="form-control">
+                    <option value="">...</option>
+                    @foreach($languages as $index => $language)
+                        <option value="{{ $index }}" @selected($index == config('app.locale'))>{{ $language['native']}}</option>
+                    @endforeach
+                </select>
             </div>
             <div class="form-group">
                 <input type="submit" class="btn btn-primary col-md-4 col-4 my-2" value="@lang('Apply filters')">

--- a/resources/views/resources/resources_filter.blade.php
+++ b/resources/views/resources/resources_filter.blade.php
@@ -66,18 +66,22 @@
                     @endforeach
                 </select>
             </div>
+            <div class="form-group col-md-3 my-3">
+                <label for="language">@lang('Language')</label>
+                <select class="form-control"
+                        name="language[]"
+                        id="language"
+                        multiple
+                        size="5"
+                >
+                    @foreach($languages as $index => $language)
+                        <option value="{{ $index }}">{{ $language['native']}}</option>
+                    @endforeach
+                </select>
+            </div>
             <div class="form-item col-12 col-md-6 my-3 {{ (Lang::locale() != 'en') ? 'ms-auto' : 'me-auto' }}">
                 <label for="search">@lang('Keywords')</label>
                 <input type="text" name="search" class="form-control" placeholder="@lang('Keywords to filter by')">
-            </div>
-            <div class="form-item col-12 col-md-6 my-3 ">
-                <label for="search">@lang('Language')</label>
-                <select name="language" class="form-control">
-                    <option value="all" @selected(request('language') === 'all')>...</option>
-                    @foreach($languages as $index => $language)
-                        <option value="{{ $index }}" @selected($index == config('app.locale') && request('language') !== 'all')>{{ $language['native']}}</option>
-                    @endforeach
-                </select>
             </div>
             <div class="form-group">
                 <input type="submit" class="btn btn-primary col-md-4 col-4 my-2" value="@lang('Apply filters')">


### PR DESCRIPTION
We currently only show search results where the resource language matches the site language. Some users may want to search resources in a different language (or across all languages).

This PR implements the following changes:
1. Adds a **Language** dropdown to the filter form, populated with all supported languages, plus an extra **`all`** option.
2. Updates the query logic so that:
   - By default, results are filtered using `config('app.locale')` (site default language).
   - Users can select a specific language to filter results by that language.
   - To search across **all languages**, users select the **`...`** (`all`) option, which disables language filtering.
3. Since `paginateResourcesBy()` is reused by multiple routes, it now applies the default language filter **only when the `language` query parameter is not provided**.

This PR belongs to [this](https://ddlibrary.atlassian.net/browse/DDL-251) Jira Ticket