### PR TITLE
Add a language filter to the resources/filter page

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\LanguageEnum;
 use App\Enums\TaxonomyVocabularyEnum;
 use App\Http\Requests\ResourceStepOneRequest;
+use App\Http\Requests\UpdateResourceFilterOptionsRequest;
 use App\Mail\NewComment;
 use App\Models\DownloadCount;
 use App\Models\Resource;
@@ -45,6 +47,8 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Mcamara\LaravelLocalization\Exceptions\SupportedLocalesNotDefined;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 use Throwable;
 
 class ResourceController extends Controller
@@ -223,27 +227,43 @@ class ResourceController extends Controller
             ->toArray();
     }
 
-    public function updateFilterOptions(Request $request){
-        $subjectAreas = (new Resource)
-            ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceSubject->value, $request->language)->where('parent', 0)
-            ->pluck('id', 'name')
-            ->toArray();
+    public function updateFilterOptions(UpdateResourceFilterOptionsRequest $request)
+    {
+        try {
+            $language = $request->input('language');
 
-        $resourceTypes = (new Resource)
-            ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceType->value , $request->language)->where('parent', 0)
-            ->pluck('id', 'name')
-            ->toArray();
+            $subjectAreas = (new Resource)
+                ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceSubject->value, $language)
+                ->where('parent', 0)
+                ->pluck('id', 'name')
+                ->toArray();
 
-        $literacyLevels = (new Resource)
-            ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceLevels->value, $request->language)->where('parent', 0)
-            ->pluck('id', 'name')
-            ->toArray();
+            $resourceTypes = (new Resource)
+                ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceType->value, $language)
+                ->where('parent', 0)
+                ->pluck('id', 'name')
+                ->toArray();
 
-        return response()->json([
-            'subjectAreas' => $subjectAreas,
-            'resourceTypes' => $resourceTypes,
-            'literacyLevels' => $literacyLevels,
-        ]);
+            $literacyLevels = (new Resource)
+                ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceLevels->value, $language)
+                ->where('parent', 0)
+                ->pluck('id', 'name')
+                ->toArray();
+
+            return response()->json([
+                'success' => true,
+                'message' => __('Filter options updated successfully.'),
+                'subjectAreas' => $subjectAreas,
+                'resourceTypes' => $resourceTypes,
+                'literacyLevels' => $literacyLevels,
+            ]);
+
+        } catch (\Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'message' => __('Something went wrong while updating filter options.')
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\LanguageEnum;
 use App\Enums\TaxonomyVocabularyEnum;
 use App\Http\Requests\ResourceStepOneRequest;
 use App\Http\Requests\UpdateResourceFilterOptionsRequest;
@@ -47,8 +46,6 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Mcamara\LaravelLocalization\Exceptions\SupportedLocalesNotDefined;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\Rule;
 use Throwable;
 
 class ResourceController extends Controller

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -141,6 +141,7 @@ class ResourceController extends Controller
     {
         // setting the search session empty
         DDLClearSession();
+        $language = $request['language'] ?? null;
         $this->pageView($request, 'Resource List');
 
         $resource = new Resource;
@@ -168,7 +169,7 @@ class ResourceController extends Controller
             if ($request->filled('subjectAreaChild')) {
                 $subjectAreaChildIds = $everything['subjectAreaChild'];
                 $parentIdsfromChildren = (new Resource)
-                    ->resourceAttributesList('taxonomy_term_data', 8)  // 8 being subject areas
+                    ->resourceAttributesList('taxonomy_term_data', 8, $language)  // 8 being subject areas
                     ->whereIn('id', $subjectAreaChildIds)
                     ->pluck('parent')
                     ->toArray();
@@ -205,19 +206,44 @@ class ResourceController extends Controller
         $literacyLevels = $resourceObject
             ->resourceAttributesList('taxonomy_term_data', 13)
             ->where('parent', 0); // 13 being resource literacy levels
+        $languages = $this->getLanguages();
 
-        return view('resources.resources_filter', compact('parentSubjects', 'resourceTypes', 'literacyLevels'));
+        return view('resources.resources_filter', compact('parentSubjects', 'languages', 'resourceTypes', 'literacyLevels'));
     }
 
     public function getSubjectChildren(Request $request): array
     {
         $subjectIds = explode(',', $request->input('IDs'));
+        $language = $request->input('language');
 
         return (new Resource)
-            ->resourceAttributesList('taxonomy_term_data', 8)  // 8 being subject areas
+            ->resourceAttributesList('taxonomy_term_data', 8, $language)  // 8 being subject areas
             ->whereIn('parent', $subjectIds)
             ->pluck('id', 'name')
             ->toArray();
+    }
+
+    public function updateFilterOptions(Request $request){
+        $subjectAreas = (new Resource)
+            ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceSubject->value, $request->language)->where('parent', 0)
+            ->pluck('id', 'name')
+            ->toArray();
+
+        $resourceTypes = (new Resource)
+            ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceType->value , $request->language)->where('parent', 0)
+            ->pluck('id', 'name')
+            ->toArray();
+
+        $literacyLevels = (new Resource)
+            ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceLevels->value, $request->language)->where('parent', 0)
+            ->pluck('id', 'name')
+            ->toArray();
+
+        return response()->json([
+            'subjectAreas' => $subjectAreas,
+            'resourceTypes' => $resourceTypes,
+            'literacyLevels' => $literacyLevels,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -224,28 +224,16 @@ class ResourceController extends Controller
             ->toArray();
     }
 
-    public function updateFilterOptions(UpdateResourceFilterOptionsRequest $request)
+    public function updateFilterOptions(UpdateResourceFilterOptionsRequest $request): JsonResponse
     {
         try {
             $language = $request->input('language');
 
-            $subjectAreas = (new Resource)
-                ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceSubject->value, $language)
-                ->where('parent', 0)
-                ->pluck('id', 'name')
-                ->toArray();
+            $subjectAreas = $this->getResourceAttributesList(TaxonomyVocabularyEnum::ResourceSubject->value, $language);
 
-            $resourceTypes = (new Resource)
-                ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceType->value, $language)
-                ->where('parent', 0)
-                ->pluck('id', 'name')
-                ->toArray();
+            $resourceTypes = $this->getResourceAttributesList(TaxonomyVocabularyEnum::ResourceType->value, $language);
 
-            $literacyLevels = (new Resource)
-                ->resourceAttributesList('taxonomy_term_data', TaxonomyVocabularyEnum::ResourceLevels->value, $language)
-                ->where('parent', 0)
-                ->pluck('id', 'name')
-                ->toArray();
+            $literacyLevels = $this->getResourceAttributesList(TaxonomyVocabularyEnum::ResourceLevels->value, $language);
 
             return response()->json([
                 'success' => true,
@@ -261,6 +249,15 @@ class ResourceController extends Controller
                 'message' => __('Something went wrong while updating filter options.')
             ], 500);
         }
+    }
+
+    private function getResourceAttributesList($vid, $language): array
+    {
+        return (new Resource)
+            ->resourceAttributesList('taxonomy_term_data', $vid, $language)
+            ->where('parent', 0)
+            ->pluck('id', 'name')
+            ->toArray();
     }
 
     /**

--- a/app/Http/Requests/UpdateResourceFilterOptionsRequest.php
+++ b/app/Http/Requests/UpdateResourceFilterOptionsRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\LanguageEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateResourceFilterOptionsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'language' => ['required', Rule::in($this->getAvailableLanguages())]
+        ];
+    }
+
+    /**
+     * Get available languages from the Enum.
+     *
+     * @return array<string>
+     */
+    private function getAvailableLanguages(): array
+    {
+        return array_map(fn ($lang) => $lang->value, LanguageEnum::cases());
+    }
+}

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -221,13 +221,14 @@ class Resource extends Model
             ->get();
     }
 
-    public function resourceAttributesList($tableName, $vid): Collection
+    public function resourceAttributesList($tableName, $vid, $language = null): Collection
     {
+        $language = $language ?? config('app.locale');
         return DB::table($tableName.' AS ttd')
             ->select('ttd.id', 'ttd.name', 'tth.parent', 'ttd.tnid')
             ->leftJoin('taxonomy_term_hierarchy AS tth', 'tth.tid', '=', 'ttd.id')
             ->where('vid', $vid)
-            ->where('language', config('app.locale'))
+            ->where('language', $language)
             ->orderBy('ttd.name')
             ->orderBy('ttd.weight', 'desc')
             ->get();
@@ -326,7 +327,15 @@ class Resource extends Model
                     ->leftJoin('resource_publishers AS rpub', 'rpub.resource_id', '=', 'rs.id')
                     ->where('rpub.tid', $request['publisher']);
             })
-            ->where('rs.language', config('app.locale'))
+            ->when(
+                $request->filled('language'),
+                function ($query) use ($request) {
+                    return $query->where('rs.language', $request['language']);
+                },
+                function ($query) {
+                    return $query->where('rs.language', config('app.locale'));
+                }
+            )
             ->where('rs.status', 1)
             ->where(function ($query) {
                 $query->where('rs.id', '>=', 11479)->orWhere('rs.id', '<', 10378); // TODO: remove after restoration

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -406,5 +406,9 @@
     "Privacy Policy": "حفظ اطلاعات شخصی",
     "Please select your gender": "لطفاً جنسیت خود را انتخاب کنید",
     "Your gender successfully updated": "جنسيت شما موفقانه ویرایش گردید.",
-    "This is a work of translation": "این یک کار ترجمه است"
+    "This is a work of translation": "این یک کار ترجمه است",
+    "Failed to load filter options. Please try again.": "گزینه‌های فیلتر بارگذاری نشد. لطفاً دوباره تلاش کنید.",
+    "Filter options updated successfully.": "گزینه‌های فیلتر با موفقیت به‌روزرسانی شد.",
+    "Something went wrong while updating filter options.": "هنگام به‌روزرسانی گزینه‌های فیلتر مشکلی رخ داده است."
+
 }

--- a/lang/ps.json
+++ b/lang/ps.json
@@ -386,8 +386,7 @@
     "Please select your gender": "مهرباني وکړئ خپل جنسيت انتخاب کړئ",
     "Your gender successfully updated": "ستاسو جنسيت په بریالیتوب سره نوي شو.",
     "This is a work of translation": "این یک کار ترجمه است",
-    "Failed to load filter options. Please try again.": "د فلټر انتخابونو په بارولو کې ستونزه ده. هیله ده بیا هڅه وکړئ.",
-    "Filter options updated successfully.": "د فلټر انتخابونه په بریالیتوب سره نوي شول.",
-    "Something went wrong while updating filter options.": "د فلټر انتخابونو د نوي کولو پرمهال ستونزه رامنځته شوه."
-
+    "Failed to load filter options. Please try again.": "د فلټر انتخابونه ښکاره نه شول. مهرباني وکړئ بیا هڅه وکړئ.",
+    "Filter options updated successfully.": "د فلټر انتخابونه په بریالیتوب سره اپډیټ شول.",
+    "Something went wrong while updating filter options.": "د فلټر د انتخابونو د اپډیټ کولو پر مهال ستونزه رامنځته شوه."
 }

--- a/lang/ps.json
+++ b/lang/ps.json
@@ -385,5 +385,9 @@
     "Privacy Policy": "د شخصي معلوماتو محرميت",
     "Please select your gender": "مهرباني وکړئ خپل جنسيت انتخاب کړئ",
     "Your gender successfully updated": "ستاسو جنسيت په بریالیتوب سره نوي شو.",
-    "This is a work of translation": "این یک کار ترجمه است"
+    "This is a work of translation": "این یک کار ترجمه است",
+    "Failed to load filter options. Please try again.": "د فلټر انتخابونو په بارولو کې ستونزه ده. هیله ده بیا هڅه وکړئ.",
+    "Filter options updated successfully.": "د فلټر انتخابونه په بریالیتوب سره نوي شول.",
+    "Something went wrong while updating filter options.": "د فلټر انتخابونو د نوي کولو پرمهال ستونزه رامنځته شوه."
+
 }

--- a/resources/assets/js/ddl.jsx
+++ b/resources/assets/js/ddl.jsx
@@ -4,6 +4,7 @@ import Cookies from 'js-cookie';
 import 'bootstrap/dist/js/bootstrap.bundle';
 import lazysizes from 'lazysizes';
 import axios from "axios";
+import './modules/resource_filter.jsx';
 
 window.Cookies = Cookies;
 window.$ = window.jQuery = $;

--- a/resources/assets/js/modules/resource_filter.jsx
+++ b/resources/assets/js/modules/resource_filter.jsx
@@ -1,0 +1,92 @@
+function appendOptions(selectElement, data) {
+  if (!selectElement || !data) return
+
+  for (const optionName in data) {
+    const optionId = data[optionName]
+    selectElement.append(new Option(optionName, optionId))
+  }
+}
+
+function toggleLoading(isLoading) {
+  const cfg = window.resourceFilterConfig
+  const btn = document.querySelector('input[type="submit"]')
+  const container = document.querySelector('#advanced-filter-container')
+
+  if (!btn || !container) return
+
+  if (isLoading) {
+    btn.disabled = true
+    btn.value = cfg.loadingText || btn.value
+    container.style.opacity = '0.6'
+  } else {
+    btn.disabled = false
+    btn.value = cfg.applyText || btn.value
+    container.style.opacity = '1'
+  }
+}
+
+function getFilterOptions() {
+  const cfg = window.resourceFilterConfig
+  const language = document.querySelector('#language').value
+  const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+
+  if (!language || !csrfToken) return
+
+  toggleLoading(true)
+  $.ajax({
+    type: 'POST',
+    url: cfg.updateOptionsUrl,
+    dataType: 'json',
+    data: { _token: csrfToken, language: language },
+    success: function (res) {
+      const subjectAreaParent = document.querySelector('#selectSubjectAreaParent');
+      const resourceType = document.querySelector('#selectResourceType');
+      const literacyLevel = document.querySelector('#selectLiteracyLevel');
+      
+      document.querySelector('#selectSubjectAreaChild').innerHTML ='';
+      subjectAreaParent.innerHTML = '';
+      resourceType.innerHTML = '';
+      literacyLevel.innerHTML = '';
+
+      appendOptions(subjectAreaParent, res.subjectAreas)
+      appendOptions(resourceType, res.resourceTypes)
+      appendOptions(literacyLevel, res.literacyLevels)
+    },
+    error: function () {
+      alert(cfg.failedMsg || 'Failed to load filter options. Please try again.')
+    },
+    complete: function () {
+      toggleLoading(false)
+    },
+  })
+}
+
+function getSubjectChildren() {
+  const language = document.querySelector('#language').value;
+  let selected_values = selectSubjectAreaParent.selectedOptions;
+  
+  selected_values = Array.from(selected_values).map(({ value }) => value);
+  $("#selectSubjectAreaChild option").remove();
+
+  $.ajax({
+    type: 'GET',
+    url: `filter/subject?IDs=${selected_values}&language=${language}`,
+    success: function (res) {
+
+      let option = document.createElement('option');
+      option.value = "";
+      selectSubjectAreaChild.append(option)
+      if (res) {
+        $.each(res, function(name, id) {
+            let option = document.createElement('option');
+            option.innerHTML = name;
+            option.value = id;
+            selectSubjectAreaChild.append(option)
+        });
+      }
+    },
+  })
+}
+
+window.getFilterOptions = getFilterOptions
+window.getSubjectChildren = getSubjectChildren

--- a/resources/assets/js/modules/resource_filter.jsx
+++ b/resources/assets/js/modules/resource_filter.jsx
@@ -1,9 +1,15 @@
+function formatOptionLabel(label) {
+  const name = String(label || '').toLowerCase()
+
+  return name.charAt(0).toUpperCase() + name.slice(1)
+}
+
 function appendOptions(selectElement, data) {
   if (!selectElement || !data) return
   selectElement.append(new Option("", ""));
   for (const optionName in data) {
     const optionId = data[optionName]
-    selectElement.append(new Option(optionName, optionId))
+    selectElement.append(new Option(formatOptionLabel(optionName), optionId))
   }
 }
 

--- a/resources/assets/js/modules/resource_filter.jsx
+++ b/resources/assets/js/modules/resource_filter.jsx
@@ -1,6 +1,6 @@
 function appendOptions(selectElement, data) {
   if (!selectElement || !data) return
-
+  selectElement.append(new Option("", ""));
   for (const optionName in data) {
     const optionId = data[optionName]
     selectElement.append(new Option(optionName, optionId))

--- a/resources/views/resources/resources_filter.blade.php
+++ b/resources/views/resources/resources_filter.blade.php
@@ -76,86 +76,11 @@
 @endsection
 @push('scripts')
     <script>
-        function getSubjectChildren() {
-            const language = document.querySelector('#language').value;
-            let selected_values = selectSubjectAreaParent.selectedOptions;
-            selected_values = Array.from(selected_values).map(({ value }) => value);
-            $("#selectSubjectAreaChild option").remove();
-
-            $.ajax({
-                type: 'GET',
-                url: `filter/subject?IDs=${selected_values}&language=${language}`,
-                success: function(res) {
-                    let option = document.createElement('option');
-                    option.value = "";
-                    selectSubjectAreaChild.append(option)
-                    if (res) {
-                        $.each(res, function(name, id) {
-                            let option = document.createElement('option');
-                            option.innerHTML = name;
-                            option.value = id;
-                            selectSubjectAreaChild.append(option)
-                        });
-                    }
-                }
-            });
-        }
-
-        function getFilterOptions() {
-            const language = document.querySelector('#language').value;
-            const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-            toggleLoading(true)
-            $.ajax({
-                type: 'POST',
-                url: "{{ route('filter.update-options') }}",
-                dataType: 'json',
-                data: { _token: csrfToken, language },
-                success: function (res) {
-                    const subjectAreaParent = document.getElementById('selectSubjectAreaParent');
-                    const resourceType = document.getElementById('selectResourceType');
-                    const literacyLevel = document.getElementById('selectLiteracyLevel');
-                    
-                    document.getElementById('selectSubjectAreaChild').innerHTML ='';
-                    subjectAreaParent.innerHTML = '';
-                    resourceType.innerHTML = '';
-                    literacyLevel.innerHTML = '';
-
-                    appendOptions(subjectAreaParent, res.subjectAreas);
-                    appendOptions(resourceType, res.resourceTypes);
-                    appendOptions(literacyLevel, res.literacyLevels);
-                },
-                error: function() {
-                    alert("@lang('Failed to load filter options. Please try again.')");
-                },
-                complete: function() {
-                    toggleLoading(false);
-                    
-                }
-            });
-        }
-
-        function appendOptions(selectElement, optionsMap) {
-            if (!optionsMap) return;
-
-            for (const optionName in optionsMap) {
-                const optionId = optionsMap[optionName];
-                selectElement.append(new Option(optionName, optionId));
-            }
-        }
-
-        function toggleLoading(isLoading) {
-            const btn = document.querySelector('input[type="submit"]');
-            const container = document.querySelector('#advanced-filter-container');
-            
-            if (isLoading) {
-                btn.disabled = true;
-                btn.value = "@lang('Loading, please wait')";
-                container.style.opacity = '0.6';
-            } else {
-                btn.disabled = false;
-                btn.value = "@lang('Apply filters')";
-                container.style.opacity = '1';
-            }
-        }
+        window.resourceFilterConfig = {
+            updateOptionsUrl: "{{ route('filter.update-options') }}",
+            failedMsg: "@lang('Failed to load filter options. Please try again.')",
+            loadingText: "@lang('Loading, please wait')",
+            applyText: "@lang('Apply filters')",
+        };
     </script>
 @endpush

--- a/resources/views/resources/resources_filter.blade.php
+++ b/resources/views/resources/resources_filter.blade.php
@@ -9,84 +9,82 @@
     {{ asset('storage/files/logo-dd.png') }}
 @endsection
 @section('content')
-    <div class="container mt-md-5 pb-4" id="advanced-filter-container">
-        <h3 class="mb-3 pt-3">@lang('Filter')</h3>
-        <form class="row justify-content-center mb-lg-2" method="GET" action="{{ route('resourceList') }}">
-            <div class="form-group col-md-3">
-                <label for="selectSubjectAreaParent">@lang('Subjects')</label>
-                <select class="form-control custom-select"
-                        name="subjectAreaParent[]"
-                        id="selectSubjectAreaParent"
-                        onchange="getSubjectChildren()"
-                        multiple
-                        size="20"
-                >
-                    <option value></option>
-                    @foreach($parentSubjects as $subject)
-                        <option value="{{ $subject->id }}" data-type="subject">{{ ucfirst(strtolower($subject->name)) }}</option>
-                    @endforeach
-                </select>
+    <form method="GET" action="{{ route('resourceList') }}">
+        <div class="container mt-md-5 pb-4" id="advanced-filter-container">
+            <h3 class="mb-3 pt-3">@lang('Filter')</h3>
+            <div class="row mb-lg-2 my-2">
+                <div class="form-group col-md-3">
+                    <label for="language">@lang('Language')</label>
+                    <select class="form-control" onchange="getFilterOptions()" name="language" id="language">
+                        @foreach ($languages as $key => $language)
+                            <option value="{{ $key }}" @selected($key == config('app.locale')) data-type="level">{{ $language['native'] }}</option>
+                        @endforeach
+                    </select>
+                </div>
             </div>
-            <div class="form-group col-md-3">
-                <label for="selectSubjectAreaChild">@lang('Subjects (sub-categories)')</label>
-                <select class="form-control"
-                        name="subjectAreaChild[]"
-                        id="selectSubjectAreaChild"
-                        multiple
-                        size="15"
-                >
-                    <option value></option>
-                </select>
+            <div class="row justify-content-center mb-lg-2">
+
+                <div class="form-group col-md-3">
+                    <label for="selectSubjectAreaParent">@lang('Subjects')</label>
+                    <select class="form-control custom-select" name="subjectAreaParent[]" id="selectSubjectAreaParent"
+                        onchange="getSubjectChildren()" multiple size="20">
+                        <option value></option>
+                        @foreach ($parentSubjects as $subject)
+                            <option value="{{ $subject->id }}" data-type="subject">
+                                {{ ucfirst(strtolower($subject->name)) }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-3">
+                    <label for="selectSubjectAreaChild">@lang('Subjects (sub-categories)')</label>
+                    <select class="form-control" name="subjectAreaChild[]" id="selectSubjectAreaChild" multiple
+                        size="15">
+                        <option value></option>
+                    </select>
+                </div>
+                <div class="form-group col-md-3">
+                    <label for="selectResourceType">@lang('Resource types')</label>
+                    <select class="form-control" name="type[]" id="selectResourceType" multiple size="15">
+                        <option value></option>
+                        @foreach ($resourceTypes as $type)
+                            <option value="{{ $type->id }}" data-type="type">{{ ucfirst(strtolower($type->name)) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-3">
+                    <label for="selectLiteracyLevel">@lang('Resource literacy levels')</label>
+                    <select class="form-control" name="level[]" id="selectLiteracyLevel" multiple size="8">
+                        <option value></option>
+                        @foreach ($literacyLevels as $level)
+                            <option value="{{ $level->id }}" data-type="level">{{ ucfirst(strtolower($level->name)) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-item col-6 my-3 {{ Lang::locale() != 'en' ? 'ms-auto' : 'me-auto' }}">
+                    <label for="search" class="sr-only">@lang('Keywords')</label>
+                    <input type="text" name="search" class="form-control" placeholder="@lang('Keywords to filter by')">
+                </div>
+                <div class="form-group">
+                    <input type="submit" class="btn btn-primary col-md-4 col-4 my-2" value="@lang('Apply filters')">
+                </div>
+                <span class="text-muted">@lang('Hold the CTRL key on Windows and Linux, and Command key (⌘) on Mac to select multiple entries.')</span>
             </div>
-            <div class="form-group col-md-3">
-                <label for="selectResourceType">@lang('Resource types')</label>
-                <select class="form-control"
-                        name="type[]"
-                        id="selectResourceType"
-                        multiple
-                        size="15"
-                >
-                    <option value></option>
-                    @foreach($resourceTypes as $type)
-                        <option value="{{ $type->id }}" data-type="type">{{ ucfirst(strtolower($type->name)) }}</option>
-                    @endforeach
-                </select>
-            </div>
-            <div class="form-group col-md-3">
-                <label for="selectLiteracyLevel">@lang('Resource literacy levels')</label>
-                <select class="form-control"
-                        name="level[]"
-                        id="selectLiteracyLevel"
-                        multiple
-                        size="8"
-                >
-                    <option value></option>
-                    @foreach($literacyLevels as $level)
-                        <option value="{{ $level->id }}" data-type="level">{{ ucfirst(strtolower($level->name)) }}</option>
-                    @endforeach
-                </select>
-            </div>
-            <div class="form-item col-6 my-3 {{ (Lang::locale() != 'en') ? 'ms-auto' : 'me-auto' }}">
-                <label for="search" class="sr-only">@lang('Keywords')</label>
-                <input type="text" name="search" class="form-control" placeholder="@lang('Keywords to filter by')">
-            </div>
-            <div class="form-group">
-                <input type="submit" class="btn btn-primary col-md-4 col-4 my-2" value="@lang('Apply filters')">
-            </div>
-        </form>
-        <span class="text-muted">@lang('Hold the CTRL key on Windows and Linux, and Command key (⌘) on Mac to select multiple entries.')</span>
-    </div>
+        </div>
+    </form>
 @endsection
 @push('scripts')
     <script>
         function getSubjectChildren() {
+            const language = document.querySelector('#language').value;
             let selected_values = selectSubjectAreaParent.selectedOptions;
             selected_values = Array.from(selected_values).map(({ value }) => value);
             $("#selectSubjectAreaChild option").remove();
 
             $.ajax({
                 type: 'GET',
-                url: 'filter/subject?IDs=' + selected_values,
+                url: `filter/subject?IDs=${selected_values}&language=${language}`,
                 success: function(res) {
                     let option = document.createElement('option');
                     option.value = "";
@@ -101,6 +99,38 @@
                     }
                 }
             });
+        }
+
+        function getFilterOptions() {
+            const language = document.querySelector('#language').value;
+            $.ajax({
+                type: 'GET',
+                url: "{{ route('filter.update-options') }}?language=" + encodeURIComponent(language),
+                success: function (res) {
+                    const subjectAreaParent = document.getElementById('selectSubjectAreaParent');
+                    const subjectChild = document.getElementById('selectSubjectAreaChild');
+                    const resourceType = document.getElementById('selectResourceType');
+                    const literacyLevel = document.getElementById('selectLiteracyLevel');
+
+                    subjectAreaParent.innerHTML = '';
+                    subjectChild.innerHTML = '';
+                    resourceType.innerHTML = '';
+                    literacyLevel.innerHTML = '';
+
+                    appendOptions(subjectAreaParent, res.subjectAreas);
+                    appendOptions(resourceType, res.resourceTypes);
+                    appendOptions(literacyLevel, res.literacyLevels);
+                }
+            });
+        }
+
+        function appendOptions(selectElement, optionsMap) {
+            if (!optionsMap) return;
+
+            for (const optionName in optionsMap) {
+                const optionId = optionsMap[optionName];
+                selectElement.append(new Option(optionName, optionId));
+            }
         }
     </script>
 @endpush

--- a/resources/views/resources/resources_filter.blade.php
+++ b/resources/views/resources/resources_filter.blade.php
@@ -103,23 +103,33 @@
 
         function getFilterOptions() {
             const language = document.querySelector('#language').value;
+            const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+            toggleLoading(true)
             $.ajax({
-                type: 'GET',
-                url: "{{ route('filter.update-options') }}?language=" + encodeURIComponent(language),
+                type: 'POST',
+                url: "{{ route('filter.update-options') }}",
+                dataType: 'json',
+                data: { _token: csrfToken, language },
                 success: function (res) {
                     const subjectAreaParent = document.getElementById('selectSubjectAreaParent');
-                    const subjectChild = document.getElementById('selectSubjectAreaChild');
                     const resourceType = document.getElementById('selectResourceType');
                     const literacyLevel = document.getElementById('selectLiteracyLevel');
-
+                    
+                    document.getElementById('selectSubjectAreaChild').innerHTML ='';
                     subjectAreaParent.innerHTML = '';
-                    subjectChild.innerHTML = '';
                     resourceType.innerHTML = '';
                     literacyLevel.innerHTML = '';
 
                     appendOptions(subjectAreaParent, res.subjectAreas);
                     appendOptions(resourceType, res.resourceTypes);
                     appendOptions(literacyLevel, res.literacyLevels);
+                },
+                error: function() {
+                    alert("@lang('Failed to load filter options. Please try again.')");
+                },
+                complete: function() {
+                    toggleLoading(false);
+                    
                 }
             });
         }
@@ -130,6 +140,21 @@
             for (const optionName in optionsMap) {
                 const optionId = optionsMap[optionName];
                 selectElement.append(new Option(optionName, optionId));
+            }
+        }
+
+        function toggleLoading(isLoading) {
+            const btn = document.querySelector('input[type="submit"]');
+            const container = document.querySelector('#advanced-filter-container');
+            
+            if (isLoading) {
+                btn.disabled = true;
+                btn.value = "@lang('Loading, please wait')";
+                container.style.opacity = '0.6';
+            } else {
+                btn.disabled = false;
+                btn.value = "@lang('Apply filters')";
+                container.style.opacity = '1';
             }
         }
     </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,7 +81,7 @@ Route::prefix(LaravelLocalization::setLocale())->middleware('localeSessionRedire
     Route::get('resources/list', [ResourceController::class, 'list'])->name('resourceList');
     Route::get('resources/filter', [ResourceController::class, 'resourceFilter'])->name('resourceFilter');
     Route::get('resources/filter/subject', [ResourceController::class, 'getSubjectChildren']);
-    Route::get('resources/filter/update-options', [ResourceController::class, 'updateFilterOptions'])->name('filter.update-options');
+    Route::post('resources/filter/update-options', [ResourceController::class, 'updateFilterOptions'])->name('filter.update-options');
     Route::get('resources/priorities', [ReportController::class, 'resourcePriorities']);
     Route::get('resources/priorities/exclusion', [ReportController::class, 'resourcePrioritiesExclusion'])->middleware('LibraryManager');
     Route::post('resources/priorities/exclusion/add/{id}', [ReportController::class, 'resourcePrioritiesExclusionModify'])->middleware('LibraryManager');

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,6 +81,7 @@ Route::prefix(LaravelLocalization::setLocale())->middleware('localeSessionRedire
     Route::get('resources/list', [ResourceController::class, 'list'])->name('resourceList');
     Route::get('resources/filter', [ResourceController::class, 'resourceFilter'])->name('resourceFilter');
     Route::get('resources/filter/subject', [ResourceController::class, 'getSubjectChildren']);
+    Route::get('resources/filter/update-options', [ResourceController::class, 'updateFilterOptions'])->name('filter.update-options');
     Route::get('resources/priorities', [ReportController::class, 'resourcePriorities']);
     Route::get('resources/priorities/exclusion', [ReportController::class, 'resourcePrioritiesExclusion'])->middleware('LibraryManager');
     Route::post('resources/priorities/exclusion/add/{id}', [ReportController::class, 'resourcePrioritiesExclusionModify'])->middleware('LibraryManager');


### PR DESCRIPTION
This PR addresses Jira Ticket: [DDL-251](https://ddlibrary.atlassian.net/jira/software/c/projects/DDL/boards/3?selectedIssue=DDL-251)

**Summary**
Added a language selection dropdown to the resource filter. Selecting a language now triggers a dynamic update, automatically refreshing the filter options (Subjects, Resource Types, and Literacy Levels) with data specific to the chosen language.

**Changes**
1. Added a language selection dropdown to the filter interface.
2. Created a `getFilterOptions` JavaScript function to fetch updated options via a `POST` request when the language changes.
3. Implemented `UpdateResourceFilterOptionsRequest` to handle and validate language-specific data fetching.
4. Added success and error message translations for Farsi and Pashto.