### PR TITLE
Fix add_news_translate route parameter mismatch

### DIFF
--- a/resources/views/news/news_add_translate.blade.php
+++ b/resources/views/news/news_add_translate.blade.php
@@ -6,7 +6,7 @@
     </header>
     <div class="content-body">
         @include('layouts.messages')
-        <form method="POST" action="{{ route('add_news_translate', ['newsid' => $tnid, 'lang' => $lang]) }}">
+        <form method="POST" action="{{ route('add_news_translate', ['newsId' => $tnid, 'lang' => $lang]) }}">
         @csrf
         <div class="form-item">
             <label for="title"> 


### PR DESCRIPTION
The route requires a specific parameter name `{newsId}`, but the view was passing a different key (`newsid`), so Laravel reported (`Missing required parameter`)