### PR TITLE
Add community forum

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,4 +2,8 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller {}
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+abstract class Controller {
+    use AuthorizesRequests;
+}

--- a/app/Http/Controllers/Forum/CategoryController.php
+++ b/app/Http/Controllers/Forum/CategoryController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Forum;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use App\Models\Thread;
+use Illuminate\Http\Request;
+
+class CategoryController extends Controller
+{
+    // GET /forum/categories
+    public function index()
+    {
+        $categories = Category::withCount('threads')->orderBy('order')->get();
+        return view('forum.categories.index', compact('categories'));
+    }
+
+    // GET /forum/categories/create
+    public function create()
+    {
+        $parents = Category::orderBy('order')->get();
+        return view('forum.categories.create', compact('parents'));
+    }
+
+    // POST /forum/categories
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name'        => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'parent_id'   => 'nullable|exists:categories,id',
+            'order'       => 'integer|min:0',
+            'is_private'  => 'boolean',
+        ]);
+
+        Category::create($validated);
+
+        return redirect()->route('categories.index')->with('alert', [
+            'message' => __('Category created.'),
+            'level'   => 'success',
+        ]);
+    }
+
+    // GET /forum/categories/{category}/edit
+    public function edit(Category $category)
+    {
+        $parents = Category::where('id', '!=', $category->id)->orderBy('order')->get();
+        return view('forum.categories.edit', compact('category', 'parents'));
+    }
+
+    // PUT /forum/categories/{category}
+    public function update(Request $request, Category $category)
+    {
+        $validated = $request->validate([
+            'name'        => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'parent_id'   => 'nullable|exists:categories,id',
+            'order'       => 'integer|min:0',
+            'is_private'  => 'boolean',
+        ]);
+
+        $category->update($validated);
+
+        return redirect()->route('categories.index')->with('alert', [
+            'message' => __('Category updated.'),
+            'level'   => 'success',
+        ]);
+    }
+
+    // DELETE /forum/categories/{category}
+    public function destroy(Category $category)
+    {
+        $category->delete();
+
+        return redirect()->route('categories.index')->with('alert', [
+            'message' => __('Category deleted.'),
+            'level'   => 'success',
+        ]);
+    }
+
+    // GET /forum/categories/{category} (public)
+    public function show(Category $category)
+    {
+        abort_if($category->is_private && !auth()->check(), 403);
+        $threads = Thread::with(['user', 'latestPost.user'])
+            ->where('category_id', $category->id)
+            ->orderByDesc('is_pinned')
+            ->orderByDesc('last_post_at')
+            ->paginate(20);
+
+        return view('forum.categories.show', compact('category', 'threads'));
+    }
+}

--- a/app/Http/Controllers/Forum/ForumUserController.php
+++ b/app/Http/Controllers/Forum/ForumUserController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Forum;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class ForumUserController extends Controller
+{
+    // PATCH /forum/users/{user}/ban
+    public function ban(User $user)
+    {
+        if ($user->forum_banned_at) {
+            $user->update(['forum_banned_at' => null]);
+            $message = __('User unbanned from forum.');
+        } else {
+            $user->update(['forum_banned_at' => now()]);
+            $message = __('User banned from forum.');
+        }
+
+        return back()->with('alert', [
+            'message' => $message,
+            'level'   => 'success',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Forum/ForumUserController.php
+++ b/app/Http/Controllers/Forum/ForumUserController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Forum;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
-use Illuminate\Http\Request;
 
 class ForumUserController extends Controller
 {

--- a/app/Http/Controllers/Forum/PostController.php
+++ b/app/Http/Controllers/Forum/PostController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Forum;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use App\Models\Thread;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    // POST /forum/threads/{thread}/posts
+    public function store(Request $request, Thread $thread)
+    {
+        abort_if($thread->is_locked, 403, 'This thread is locked.');
+        abort_if(auth()->user()->isForumBanned(), 403, __('You are banned from the forum.'));
+
+        $validated = $request->validate([
+            'body' => 'required|string|min:3',
+        ]);
+
+        $thread->posts()->create([
+            ...$validated,
+            'user_id' => auth()->id(),
+        ]);
+
+        // Redirect to the last page so user sees their new post
+        $lastPage = $thread->posts()->paginate(25)->lastPage();
+
+        return redirect()->route('threads.show', [$thread, 'page' => $lastPage])
+            ->withFragment('posts');
+    }
+
+    // PUT /forum/threads/{thread}/posts/{post}
+    public function update(Request $request, Thread $thread, Post $post)
+    {
+        $this->authorize('update', $post);
+
+        $validated = $request->validate([
+            'body' => 'required|string|min:3',
+        ]);
+
+        $post->update($validated);
+
+        return redirect()->route('threads.show', $thread);
+    }
+
+    // DELETE /forum/threads/{thread}/posts/{post}
+    public function destroy(Thread $thread, Post $post)
+    {
+        $this->authorize('delete', $post);
+
+        $post->delete();
+
+        return redirect()->route('threads.show', $thread);
+    }
+}

--- a/app/Http/Controllers/Forum/ThreadController.php
+++ b/app/Http/Controllers/Forum/ThreadController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\Forum;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use App\Models\Thread;
+use Illuminate\Http\Request;
+
+class ThreadController extends Controller
+{
+    // GET /forum
+    public function index()
+    {
+        $threads = Thread::with(['user', 'category', 'latestPost.user'])
+            ->when(!auth()->check(), fn($q) => $q->whereHas('category', fn($q) => $q->where('is_private', false)))
+            ->orderByDesc('is_pinned')
+            ->orderByDesc('last_post_at')
+            ->paginate(20);
+
+        return view('forum.threads.index', compact('threads'));
+    }
+
+    // GET /forum/threads/create
+    public function create()
+    {
+        $categories = Category::orderBy('order')->get();
+        return view('forum.threads.create', compact('categories'));
+    }
+
+    // POST /forum/threads
+    public function store(Request $request)
+    {
+        abort_if(auth()->user()->isForumBanned(), 403, __('You are banned from the forum.'));
+        $validated = $request->validate([
+            'title'       => 'required|string|min:5|max:255',
+            'body'        => 'required|string|min:10',
+            'category_id' => 'required|exists:categories,id',
+        ]);
+
+        $thread = auth()->user()->threads()->create($validated);
+
+        return redirect()->route('threads.show', $thread);
+    }
+
+    // GET /forum/threads/{thread}
+    public function show(Thread $thread)
+    {
+        $posts = $thread->posts()->with('user')->paginate(25);
+
+        return view('forum.threads.show', compact('thread', 'posts'));
+    }
+
+    // GET /forum/threads/{thread}/edit
+    public function edit(Thread $thread)
+    {
+        $this->authorize('update', $thread);
+
+        $categories = Category::orderBy('order')->get();
+        return view('forum.threads.edit', compact('thread', 'categories'));
+    }
+
+    // PUT /forum/threads/{thread}
+    public function update(Request $request, Thread $thread)
+    {
+        $this->authorize('update', $thread);
+
+        $validated = $request->validate([
+            'title'       => 'required|string|min:5|max:255',
+            'body'        => 'required|string|min:10',
+            'category_id' => 'required|exists:categories,id',
+        ]);
+
+        $thread->update($validated);
+
+        return redirect()->route('threads.show', $thread);
+    }
+
+    // DELETE /forum/threads/{thread}
+    public function destroy(Thread $thread)
+    {
+        $this->authorize('delete', $thread);
+
+        $thread->delete();
+
+        return redirect()->route('threads.index');
+    }
+
+    // PATCH /forum/threads/{thread}/lock
+    public function lock(Thread $thread)
+    {
+        $thread->update(['is_locked' => !$thread->is_locked]);
+
+        return back()->with('alert', [
+            'message' => $thread->is_locked ? __('Thread locked.') : __('Thread unlocked.'),
+            'level'   => 'success',
+        ]);
+    }
+
+    // PATCH /forum/threads/{thread}/pin
+    public function pin(Thread $thread)
+    {
+        $thread->update(['is_pinned' => !$thread->is_pinned]);
+
+        return back()->with('alert', [
+            'message' => $thread->is_pinned ? __('Thread pinned.') : __('Thread unpinned.'),
+            'level'   => 'success',
+        ]);
+    }
+
+    // PATCH /forum/threads/{thread}/move
+    public function move(Request $request, Thread $thread)
+    {
+        $request->validate([
+            'category_id' => 'required|exists:categories,id',
+        ]);
+
+        $thread->update(['category_id' => $request->category_id]);
+
+        return back()->with('alert', [
+            'message' => __('Thread moved.'),
+            'level'   => 'success',
+        ]);
+    }
+}

--- a/app/Http/Middleware/RedirectIfAdmin.php
+++ b/app/Http/Middleware/RedirectIfAdmin.php
@@ -15,7 +15,7 @@ class RedirectIfAdmin
     {
         if (Auth::guard($guard)->check()) {
             if (! isAdmin()) {
-                return redirect('/home');
+                abort(403);
             }
         } else {
             return redirect('/login');

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -10,7 +11,7 @@ use Spatie\Sluggable\SlugOptions;
 
 class Category extends Model
 {
-    use HasSlug;
+    use HasFactory, HasSlug;
     protected $fillable = ['name', 'slug', 'description', 'parent_id', 'order', 'is_private'];
 
     public function parent(): BelongsTo

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Sluggable\HasSlug;
+use Spatie\Sluggable\SlugOptions;
+
+class Category extends Model
+{
+    use HasSlug;
+    protected $fillable = ['name', 'slug', 'description', 'parent_id', 'order', 'is_private'];
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(Category::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(Category::class, 'parent_id')->orderBy('order');
+    }
+
+    public function threads(): HasMany
+    {
+        return $this->hasMany(Thread::class);
+    }
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Post extends Model
+{
+    protected $fillable = ['thread_id', 'user_id', 'body', 'is_solution'];
+
+    protected $casts = [
+        'is_solution' => 'boolean',
+    ];
+
+    public function thread(): BelongsTo
+    {
+        return $this->belongsTo(Thread::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::created(function (Post $post) {
+            $post->thread->touch('last_post_at');
+        });
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,16 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Post extends Model
 {
-    protected $fillable = ['thread_id', 'user_id', 'body', 'is_solution'];
-
-    protected $casts = [
-        'is_solution' => 'boolean',
-    ];
+    use HasFactory;
+    protected $fillable = ['thread_id', 'user_id', 'body'];
 
     public function thread(): BelongsTo
     {

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -11,7 +12,7 @@ use Spatie\Sluggable\SlugOptions;
 
 class Thread extends Model
 {
-    use HasSlug;
+    use HasFactory, HasSlug;
 
     protected $fillable = [
         'user_id', 'category_id', 'title', 'slug', 'body',

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Spatie\Sluggable\HasSlug;
+use Spatie\Sluggable\SlugOptions;
+
+class Thread extends Model
+{
+    use HasSlug;
+
+    protected $fillable = [
+        'user_id', 'category_id', 'title', 'slug', 'body',
+        'is_locked', 'is_pinned', 'last_post_at',
+    ];
+
+    protected $casts = [
+        'is_locked' => 'boolean',
+        'is_pinned' => 'boolean',
+        'last_post_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class)->oldest();
+    }
+
+    public function latestPost(): HasOne
+    {
+        return $this->hasOne(Post::class)->latestOfMany();
+    }
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('title')
+            ->saveSlugsTo('slug');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,10 @@ class User extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens, HasFactory, Notifiable;
 
+    protected $fillable = [
+        'forum_banned_at',
+    ];
+
     public function resource(): HasMany
     {
         return $this->hasMany(Resource::class);
@@ -76,6 +80,16 @@ class User extends Authenticatable implements MustVerifyEmail
     public function subscription(): HasOne
     {
         return $this->hasOne(Subscriber::class);
+    }
+
+    public function threads(): HasMany
+    {
+        return $this->hasMany(Thread::class);
+    }
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
     }
 
     /**
@@ -269,6 +283,11 @@ class User extends Authenticatable implements MustVerifyEmail
             ->where('users.id', $userId)
             ->where('user_roles.role_id', 3)
             ->first();
+    }
+
+    public function isForumBanned(): bool
+    {
+        return $this->forum_banned_at !== null;
     }
 
     public function getAvatarAttribute()

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id || isAdmin();
+    }
+
+    public function delete(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id || isAdmin();
+    }
+}

--- a/app/Policies/ThreadPolicy.php
+++ b/app/Policies/ThreadPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Thread;
+use App\Models\User;
+
+class ThreadPolicy
+{
+    public function update(User $user, Thread $thread): bool
+    {
+        return $user->id === $thread->user_id || isAdmin();
+    }
+
+    public function delete(User $user, Thread $thread): bool
+    {
+        return $user->id === $thread->user_id || isAdmin();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "spatie/laravel-activitylog": "^4.12",
         "spatie/laravel-analytics": "^5.7",
         "spatie/laravel-honeypot": "^4.7",
+        "spatie/laravel-sluggable": "^4.0",
         "tinymce/tinymce": "^8.3",
         "usmanhalalit/laracsv": "^2.1",
         "yajra/laravel-datatables-oracle": "^12.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e7391f0c29e956031f0498a1b2125f9",
+    "content-hash": "2c0c3ef567300edf2126477351e32f58",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6013,6 +6013,84 @@
                 }
             ],
             "time": "2026-05-19T14:06:37+00:00"
+        },
+        {
+            "name": "spatie/laravel-sluggable",
+            "version": "4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-sluggable.git",
+                "reference": "82a69be1ef661ce2ff38242b271457ef0b9611dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-sluggable/zipball/82a69be1ef661ce2ff38242b271457ef0b9611dd",
+                "reference": "82a69be1ef661ce2ff38242b271457ef0b9611dd",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/support": "^12.0|^13.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.24",
+                "orchestra/testbench": "^10.0|^11.0",
+                "pestphp/pest": "^4.0",
+                "spatie/laravel-translatable": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "SelfHealing": "Spatie\\Sluggable\\Facades\\SelfHealing"
+                    },
+                    "providers": [
+                        "Spatie\\Sluggable\\SluggableServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Sluggable\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Generate slugs when saving Eloquent models",
+            "homepage": "https://github.com/spatie/laravel-sluggable",
+            "keywords": [
+                "eloquent",
+                "laravel",
+                "laravel-sluggable",
+                "self-healing",
+                "slug",
+                "slugs",
+                "spatie",
+                "translatable"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-sluggable/issues",
+                "source": "https://github.com/spatie/laravel-sluggable/tree/4.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-30T17:28:09+00:00"
         },
         {
             "name": "symfony/cache",

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CategoryFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name'        => $this->faker->unique()->words(3, true),
+            'description' => $this->faker->sentence(),
+            'parent_id'   => null,
+            'order'       => $this->faker->numberBetween(0, 10),
+            'is_private'  => false,
+        ];
+    }
+
+    public function private(): static
+    {
+        return $this->state(['is_private' => true]);
+    }
+}

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Thread;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PostFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'thread_id'   => Thread::factory(),
+            'user_id'     => User::factory(),
+            'body'        => $this->faker->paragraph(),
+        ];
+    }
+}

--- a/database/factories/ThreadFactory.php
+++ b/database/factories/ThreadFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ThreadFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id'     => User::factory(),
+            'category_id' => Category::factory(),
+            'title'       => $this->faker->sentence(),
+            'body'        => $this->faker->paragraphs(2, true),
+            'is_locked'   => false,
+            'is_pinned'   => false,
+            'last_post_at' => null,
+        ];
+    }
+
+    public function locked(): static
+    {
+        return $this->state(['is_locked' => true]);
+    }
+
+    public function pinned(): static
+    {
+        return $this->state(['is_pinned' => true]);
+    }
+}

--- a/database/migrations/2026_06_16_062237_create_categories_table.php
+++ b/database/migrations/2026_06_16_062237_create_categories_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->foreignId('parent_id')
+                ->nullable()
+                ->constrained('categories')
+                ->nullOnDelete();                   // for sub-categories
+            $table->integer('order')->default(0);     // display ordering
+            $table->boolean('is_private')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2026_06_16_062240_create_threads_table.php
+++ b/database/migrations/2026_06_16_062240_create_threads_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('threads', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreignId('category_id')->constrained();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('body');
+            $table->boolean('is_locked')->default(false);
+            $table->boolean('is_pinned')->default(false);
+            $table->timestamp('last_post_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('threads');
+    }
+};

--- a/database/migrations/2026_06_16_062241_create_posts_table.php
+++ b/database/migrations/2026_06_16_062241_create_posts_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('thread_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/database/migrations/2026_06_24_045140_add_forum_banned_at_to_users_table.php
+++ b/database/migrations/2026_06_24_045140_add_forum_banned_at_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('forum_banned_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('forum_banned_at');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,11 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "html",
             "dependencies": {
                 "@fontsource/eb-garamond": "^5.2.7",
                 "@fontsource/inter": "^5.2.8",
                 "@fontsource/noto-kufi-arabic": "^5.2.9",
-                "@fortawesome/fontawesome-free": "^6.7.2",
                 "@phosphor-icons/web": "^2.1.2",
                 "@popperjs/core": "^2.11.6",
                 "axios": "^1.15.0",
@@ -90,15 +90,6 @@
             "license": "OFL-1.1",
             "funding": {
                 "url": "https://github.com/sponsors/ayuhito"
-            }
-        },
-        "node_modules/@fortawesome/fontawesome-free": {
-            "version": "6.7.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-            "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
-            "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
@@ -1247,16 +1238,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "@fontsource/eb-garamond": "^5.2.7",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/noto-kufi-arabic": "^5.2.9",
-        "@fortawesome/fontawesome-free": "^6.7.2",
         "@phosphor-icons/web": "^2.1.2",
         "@popperjs/core": "^2.11.6",
         "axios": "^1.15.0",

--- a/resources/assets/sass/_icons.scss
+++ b/resources/assets/sass/_icons.scss
@@ -1,3 +1,15 @@
+.navbar {
+  .ph-fill {
+    font-size: 1.4rem;
+  }
+}
+
+.navbar .user-icon {
+  .ph-fill {
+    font-size: 1.6rem;
+  }
+}
+
 .home-subject-areas {
   .ph-light {
     font-size: 6rem;
@@ -43,6 +55,6 @@
   font-size: 1.5rem;
 }
 
-.filter-icon {
+.search-icons {
   font-size: 1.5rem;
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -14,12 +14,6 @@
 // Bootstrap
 @import 'bootstrap/scss/bootstrap';
 
-// Font Awesome
-@import '@fortawesome/fontawesome-free/scss/fontawesome';
-@import '@fortawesome/fontawesome-free/scss/regular';
-@import '@fortawesome/fontawesome-free/scss/solid';
-@import '@fortawesome/fontawesome-free/scss/brands';
-
 // Phosphor Icons
 @import '@phosphor-icons/web/light';
 @import '@phosphor-icons/web/fill';

--- a/resources/views/forum/categories/create.blade.php
+++ b/resources/views/forum/categories/create.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.main')
+
+@section('title', __('New Category'))
+
+@section('content')
+<div class="container py-4" style="max-width: 620px;">
+    <h1 class="h3 mb-4">@lang('New Category')</h1>
+
+    <form action="{{ route('categories.store') }}" method="POST">
+        @csrf
+
+        <div class="mb-3">
+            <label for="name" class="form-label">@lang('Name')</label>
+            <input type="text" name="name" id="name" value="{{ old('name') }}"
+                class="form-control @error('name') is-invalid @enderror" required>
+            @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="mb-3">
+            <label for="description" class="form-label">@lang('Description')</label>
+            <textarea name="description" id="description" rows="3"
+                class="form-control @error('description') is-invalid @enderror">{{ old('description') }}</textarea>
+            @error('description') <div class="invalid-feedback">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="mb-3">
+            <label for="parent_id" class="form-label">@lang('Parent Category')</label>
+            <select name="parent_id" id="parent_id" class="form-select">
+                <option value="">@lang('None (top level)')</option>
+                @foreach($parents as $parent)
+                    <option value="{{ $parent->id }}" @selected(old('parent_id') == $parent->id)>
+                        {{ $parent->name }}
+                    </option>
+                @endforeach
+            </select>
+        </div>
+
+        <div class="mb-3">
+            <label for="order" class="form-label">@lang('Display Order')</label>
+            <input type="number" name="order" id="order" value="{{ old('order', 0) }}"
+                class="form-control" min="0">
+        </div>
+
+        <div class="mb-4">
+            <div class="form-check">
+                <input type="hidden" name="is_private" value="0">
+                <input class="form-check-input" type="checkbox" name="is_private" id="is_private"
+                    value="1" @checked(old('is_private'))>
+                <label class="form-check-label" for="is_private">@lang('Private (logged-in users only)')</label>
+            </div>
+        </div>
+
+        <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-primary">@lang('Create Category')</button>
+            <a href="{{ route('categories.index') }}" class="btn btn-outline-secondary">@lang('Cancel')</a>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/forum/categories/edit.blade.php
+++ b/resources/views/forum/categories/edit.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.main')
+
+@section('title', __('Edit Category'))
+
+@section('content')
+    <div class="container py-4" style="max-width: 620px;">
+        <h1 class="h3 mb-4">@lang('Edit Category')</h1>
+
+        <form action="{{ route('categories.update', $category) }}" method="POST">
+            @csrf @method('PUT')
+
+            <div class="mb-3">
+                <label for="name" class="form-label">@lang('Name')</label>
+                <input type="text" name="name" id="name" value="{{ old('name', $category->name) }}"
+                       class="form-control @error('name') is-invalid @enderror" required>
+                @error('name') <div class="invalid-feedback">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="description" class="form-label">@lang('Description')</label>
+                <textarea name="description" id="description" rows="3"
+                          class="form-control">{{ old('description', $category->description) }}</textarea>
+            </div>
+
+            <div class="mb-3">
+                <label for="parent_id" class="form-label">@lang('Parent Category')</label>
+                <select name="parent_id" id="parent_id" class="form-select">
+                    <option value="">@lang('None (top level)')</option>
+                    @foreach($parents as $parent)
+                        <option value="{{ $parent->id }}" @selected(old('parent_id', $category->parent_id) == $parent->id)>
+                            {{ $parent->name }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+
+            <div class="mb-3">
+                <label for="order" class="form-label">@lang('Display Order')</label>
+                <input type="number" name="order" id="order"
+                       value="{{ old('order', $category->order) }}" class="form-control" min="0">
+            </div>
+
+            <div class="mb-4">
+                <div class="form-check">
+                    <input type="hidden" name="is_private" value="0">
+                    <input class="form-check-input" type="checkbox" name="is_private" id="is_private"
+                           value="1" @checked(old('is_private', $category->is_private))>
+                    <label class="form-check-label" for="is_private">@lang('Private (logged-in users only)')</label>
+                </div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">@lang('Save Changes')</button>
+                <a href="{{ route('categories.index') }}" class="btn btn-outline-secondary">@lang('Cancel')</a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/forum/categories/index.blade.php
+++ b/resources/views/forum/categories/index.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.main')
+
+@section('title', __('Manage Categories'))
+
+@section('content')
+    <div class="container py-4" style="max-width: 860px;">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="h3 mb-0">@lang('Forum Categories')</h1>
+            <a href="{{ route('categories.create') }}" class="btn btn-primary">@lang('New Category')</a>
+        </div>
+
+        @if($categories->isEmpty())
+            <div class="alert alert-light">@lang('No categories yet.')</div>
+        @else
+            <div class="table-responsive">
+                <table class="table table-bordered align-middle">
+                    <thead class="table-light">
+                    <tr>
+                        <th>@lang('Name')</th>
+                        <th>@lang('Description')</th>
+                        <th>@lang('Parent')</th>
+                        <th>@lang('Order')</th>
+                        <th>@lang('Threads')</th>
+                        <th>@lang('Private')</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    @foreach($categories as $category)
+                        <tr>
+                            <td>{{ $category->name }}</td>
+                            <td class="text-muted small">{{ $category->description ?? '—' }}</td>
+                            <td>{{ $category->parent?->name ?? '—' }}</td>
+                            <td>{{ $category->order }}</td>
+                            <td>{{ $category->threads_count }}</td>
+                            <td>
+                                @if($category->is_private)
+                                    <span class="badge bg-warning text-dark">@lang('Yes')</span>
+                                @else
+                                    <span class="badge bg-light text-muted">@lang('No')</span>
+                                @endif
+                            </td>
+                            <td class="text-end">
+                                <a href="{{ route('categories.edit', $category) }}" class="btn btn-sm btn-outline-secondary">@lang('Edit')</a>
+                                <form action="{{ route('categories.destroy', $category) }}" method="POST"
+                                      class="d-inline" onsubmit="return confirm('{{ __('Delete this category?') }}')">
+                                    @csrf @method('DELETE')
+                                    <button class="btn btn-sm btn-outline-danger">@lang('Delete')</button>
+                                </form>
+                            </td>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    </div>
+@endsection

--- a/resources/views/forum/categories/show.blade.php
+++ b/resources/views/forum/categories/show.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.main')
+
+@section('title', $category->name)
+
+@section('content')
+    <div class="container py-4">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <div>
+                <a href="{{ route('threads.index') }}" class="text-muted text-decoration-none small">← @lang('Forum')</a>
+                <h1 class="h3 mb-0 mt-1">{{ $category->name }}</h1>
+                @if($category->description)
+                    <p class="text-muted mb-0">{{ $category->description }}</p>
+                @endif
+            </div>
+            @auth
+                <a href="{{ route('threads.create') }}" class="btn btn-primary">@lang('New Thread')</a>
+            @endauth
+        </div>
+
+        @forelse($threads as $thread)
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            @if($thread->is_pinned)
+                                <span class="badge bg-warning text-dark me-1">@lang('Pinned')</span>
+                            @endif
+                            @if($thread->is_locked)
+                                <span class="badge bg-secondary me-1">@lang('Locked')</span>
+                            @endif
+                            <a href="{{ route('threads.show', $thread) }}" class="fw-bold text-decoration-none fs-5">
+                                {{ $thread->title }}
+                            </a>
+                            <div class="text-muted small mt-1">
+                                @lang('by') <strong>{{ $thread->user->username }}</strong>
+                                · {{ $thread->created_at->diffForHumans() }}
+                            </div>
+                        </div>
+                        <div class="text-end text-muted small">
+                            <div>{{ $thread->posts()->count() }} @lang('replies')</div>
+                            @if($thread->last_post_at)
+                                <div>@lang('Last reply') {{ $thread->last_post_at->diffForHumans() }}</div>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @empty
+            <div class="alert alert-light">@lang('No threads in this category yet.')</div>
+        @endforelse
+
+        {{ $threads->links() }}
+    </div>
+@endsection

--- a/resources/views/forum/threads/create.blade.php
+++ b/resources/views/forum/threads/create.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.main')
+
+@section('title', __('New Thread'))
+
+@section('content')
+    <div class="container py-4" style="max-width: 760px;">
+        <h1 class="h3 mb-4">@lang('New Thread')</h1>
+
+        <form action="{{ route('threads.store') }}" method="POST">
+            @csrf
+
+            <div class="mb-3">
+                <label for="category_id" class="form-label">@lang('Category')</label>
+                <select name="category_id" id="category_id" class="form-select @error('category_id') is-invalid @enderror" required>
+                    <option value="" disabled selected>@lang('Select a category')</option>
+                    @foreach($categories as $category)
+                        <option value="{{ $category->id }}" @selected(old('category_id') == $category->id)>
+                            {{ $category->name }}
+                        </option>
+                    @endforeach
+                </select>
+                @error('category_id')
+                <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="title" class="form-label">@lang('Title')</label>
+                <input type="text" name="title" id="title" value="{{ old('title') }}"
+                       class="form-control @error('title') is-invalid @enderror" required>
+                @error('title')
+                <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="body" class="form-label">@lang('Body')</label>
+                <textarea name="body" id="body" rows="8"
+                          class="form-control @error('body') is-invalid @enderror" required>{{ old('body') }}</textarea>
+                @error('body')
+                <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">@lang('Post Thread')</button>
+                <a href="{{ route('threads.index') }}" class="btn btn-outline-secondary">@lang('Cancel')</a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/forum/threads/edit.blade.php
+++ b/resources/views/forum/threads/edit.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.main')
+
+@section('title', __('Edit Thread'))
+
+@section('content')
+    <div class="container py-4" style="max-width: 760px;">
+        <h1 class="h3 mb-4">@lang('Edit Thread')</h1>
+
+        <form action="{{ route('threads.update', $thread) }}" method="POST">
+            @csrf @method('PUT')
+
+            <div class="mb-3">
+                <label for="category_id" class="form-label">@lang('Category')</label>
+                <select name="category_id" id="category_id" class="form-select @error('category_id') is-invalid @enderror">
+                    @foreach($categories as $category)
+                        <option value="{{ $category->id }}" @selected(old('category_id', $thread->category_id) == $category->id)>
+                            {{ $category->name }}
+                        </option>
+                    @endforeach
+                </select>
+                @error('category_id') <div class="invalid-feedback">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="title" class="form-label">@lang('Title')</label>
+                <input type="text" name="title" id="title"
+                       value="{{ old('title', $thread->title) }}"
+                       class="form-control @error('title') is-invalid @enderror">
+                @error('title') <div class="invalid-feedback">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="body" class="form-label">@lang('Body')</label>
+                <textarea name="body" id="body" rows="8"
+                          class="form-control @error('body') is-invalid @enderror">{{ old('body', $thread->body) }}</textarea>
+                @error('body') <div class="invalid-feedback">{{ $message }}</div> @enderror
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">@lang('Save Changes')</button>
+                <a href="{{ route('threads.show', $thread) }}" class="btn btn-outline-secondary">@lang('Cancel')</a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/forum/threads/index.blade.php
+++ b/resources/views/forum/threads/index.blade.php
@@ -1,0 +1,57 @@
+@extends('layouts.main')
+
+@section('title', __('Forum'))
+
+@section('content')
+    <div class="container py-4">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="h3 mb-0">@lang('Forum')</h1>
+            @auth
+                <a href="{{ route('threads.create') }}" class="btn btn-primary">@lang('New Thread')</a>
+                @if(isAdmin())
+                    <a href="{{ route('categories.index') }}" class="btn btn-outline-secondary btn-sm">
+                        @lang('Manage Categories')
+                    </a>
+                @endif
+            @endauth
+        </div>
+
+        @forelse($threads as $thread)
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            @if($thread->is_pinned)
+                                <span class="badge bg-warning text-dark me-1">@lang('Pinned')</span>
+                            @endif
+                            @if($thread->is_locked)
+                                <span class="badge bg-secondary me-1">@lang('Locked')</span>
+                            @endif
+                            <a href="{{ route('threads.show', $thread) }}" class="fw-bold text-decoration-none fs-5">
+                                {{ $thread->title }}
+                            </a>
+                            <div class="text-muted small mt-1">
+                                @lang('by') <strong>{{ $thread->user->username }}</strong>
+                                @lang('in')
+                                <a href="{{ route('threads.categories.show', $thread->category) }}">
+                                    {{ $thread->category->name }}
+                                </a>
+                                · {{ $thread->created_at->diffForHumans() }}
+                            </div>
+                        </div>
+                        <div class="text-end text-muted small">
+                            <div>{{ $thread->posts_count ?? $thread->posts()->count() }} @lang('replies')</div>
+                            @if($thread->latestPost)
+                                <div>@lang('Last reply') {{ $thread->last_post_at->diffForHumans() }}</div>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @empty
+            <div class="alert alert-light">@lang('No threads yet. Be the first to post!')</div>
+        @endforelse
+
+        {{ $threads->links() }}
+    </div>
+@endsection

--- a/resources/views/forum/threads/index.blade.php
+++ b/resources/views/forum/threads/index.blade.php
@@ -10,7 +10,7 @@
                 <p class="text-muted mb-0">@lang('Ask, share, and learn together')</p>
             </div>
             @auth
-                <a href="{{ route('threads.create') }}" class="btn btn-primary">@lang('New Thread')</a>
+                <a href="{{ route('threads.create') }}" class="btn btn-primary me-1">@lang('New Thread')</a>
                 @if(isAdmin())
                     <a href="{{ route('categories.index') }}" class="btn btn-outline-secondary btn-sm">
                         @lang('Manage Categories')

--- a/resources/views/forum/threads/index.blade.php
+++ b/resources/views/forum/threads/index.blade.php
@@ -5,7 +5,10 @@
 @section('content')
     <div class="container py-4">
         <div class="d-flex justify-content-between align-items-center mb-4">
-            <h1 class="h3 mb-0">@lang('Forum')</h1>
+            <div>
+                <h3 class="h3 mb-0">@lang('Forum')</h3>
+                <p class="text-muted mb-0">@lang('Ask, share, and learn together')</p>
+            </div>
             @auth
                 <a href="{{ route('threads.create') }}" class="btn btn-primary">@lang('New Thread')</a>
                 @if(isAdmin())

--- a/resources/views/forum/threads/show.blade.php
+++ b/resources/views/forum/threads/show.blade.php
@@ -1,0 +1,168 @@
+@extends('layouts.main')
+
+@section('title', $thread->title)
+
+@section('content')
+    <div class="container py-4" style="max-width: 860px;">
+
+        {{-- Thread header --}}
+        <div class="mb-3">
+            <a href="{{ route('threads.index') }}" class="text-muted text-decoration-none small">
+                ← @lang('Back to Forum')
+            </a>
+        </div>
+        @if(isAdmin())
+            <div class="card mb-4 border-warning">
+                <div class="card-body py-2">
+                    <div class="d-flex flex-wrap gap-2 align-items-center">
+                        <span class="text-muted small fw-bold me-2">@lang('Moderation')</span>
+
+                        {{-- Lock/Unlock --}}
+                        <form action="{{ route('threads.lock', $thread) }}" method="POST">
+                            @csrf @method('PATCH')
+                            <button class="btn btn-sm {{ $thread->is_locked ? 'btn-success' : 'btn-warning' }}">
+                                {{ $thread->is_locked ? __('Unlock') : __('Lock') }}
+                            </button>
+                        </form>
+
+                        {{-- Pin/Unpin --}}
+                        <form action="{{ route('threads.pin', $thread) }}" method="POST">
+                            @csrf @method('PATCH')
+                            <button class="btn btn-sm {{ $thread->is_pinned ? 'btn-secondary' : 'btn-primary' }}">
+                                {{ $thread->is_pinned ? __('Unpin') : __('Pin') }}
+                            </button>
+                        </form>
+
+                        {{-- Move --}}
+                        <form action="{{ route('threads.move', $thread) }}" method="POST" class="d-flex gap-1">
+                            @csrf @method('PATCH')
+                            <select name="category_id" class="form-select form-select-sm" style="width:auto;">
+                                @foreach(\App\Models\Category::orderBy('order')->get() as $cat)
+                                    <option value="{{ $cat->id }}" @selected($cat->id === $thread->category_id)>
+                                        {{ $cat->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            <button class="btn btn-sm btn-outline-primary">@lang('Move')</button>
+                        </form>
+
+                        {{-- Delete thread --}}
+                        <form action="{{ route('threads.destroy', $thread) }}" method="POST"
+                              onsubmit="return confirm('{{ __('Delete this thread and all its replies?') }}')">
+                            @csrf @method('DELETE')
+                            <button class="btn btn-sm btn-danger">@lang('Delete Thread')</button>
+                        </form>
+
+                        {{-- Ban thread author --}}
+                        <form action="{{ route('forum.users.ban', $thread->user) }}" method="POST"
+                              onsubmit="return confirm('{{ __('Toggle forum ban for this user?') }}')">
+                            @csrf @method('PATCH')
+                            <button class="btn btn-sm {{ $thread->user->isForumBanned() ? 'btn-outline-success' : 'btn-outline-danger' }}">
+                                {{ $thread->user->isForumBanned() ? __('Unban User') : __('Ban User') }}
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        @endif
+
+        <div class="card mb-4">
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        @if($thread->is_pinned)
+                            <span class="badge bg-warning text-dark me-1">@lang('Pinned')</span>
+                        @endif
+                        @if($thread->is_locked)
+                            <span class="badge bg-secondary me-1">@lang('Locked')</span>
+                        @endif
+                        <h1 class="h4">{{ $thread->title }}</h1>
+                        <div class="text-muted small">
+                            @lang('by') <strong>{{ $thread->user->username }}</strong>
+                            · {{ $thread->created_at->diffForHumans() }}
+                            · <a href="{{ route('threads.categories.show', $thread->category) }}">{{ $thread->category->name }}</a>
+                        </div>
+                    </div>
+                    @can('update', $thread)
+                        <div class="dropdown">
+                            <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
+                                @lang('Manage')
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end">
+                                <li>
+                                    <a class="dropdown-item" href="{{ route('threads.edit', $thread) }}">@lang('Edit')</a>
+                                </li>
+                                <li>
+                                    <form action="{{ route('threads.destroy', $thread) }}" method="POST"
+                                          onsubmit="return confirm('{{ __('Delete this thread?') }}')">
+                                        @csrf @method('DELETE')
+                                        <button class="dropdown-item text-danger">@lang('Delete')</button>
+                                    </form>
+                                </li>
+                            </ul>
+                        </div>
+                    @endcan
+                </div>
+                <hr>
+                <div class="mt-2">{!! nl2br(e($thread->body)) !!}</div>
+            </div>
+        </div>
+
+        {{-- Posts / replies --}}
+        <h5 class="mb-3">@lang('Replies')</h5>
+
+        @forelse($posts as $post)
+            <div class="card mb-3" id="post-{{ $post->id }}">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div class="text-muted small">
+                            <strong>{{ $post->user->username }}</strong> · {{ $post->created_at->diffForHumans() }}
+                        </div>
+                        @can('delete', $post)
+                            <form action="{{ route('posts.destroy', [$thread, $post]) }}" method="POST"
+                                  onsubmit="return confirm('{{ __('Delete this reply?') }}')">
+                                @csrf @method('DELETE')
+                                <button class="btn btn-sm btn-link text-danger p-0">@lang('Delete')</button>
+                            </form>
+                        @endcan
+                    </div>
+                    <div class="mt-2">{!! nl2br(e($post->body)) !!}</div>
+                </div>
+            </div>
+        @empty
+            <div class="alert alert-light">@lang('No replies yet.')</div>
+        @endforelse
+
+        {{ $posts->links() }}
+
+        {{-- Reply form --}}
+        @auth
+            @if(!$thread->is_locked)
+                <div class="card mt-4" id="posts">
+                    <div class="card-body">
+                        <h6 class="mb-3">@lang('Leave a Reply')</h6>
+                        <form action="{{ route('threads.posts.store', $thread) }}" method="POST">
+                            @csrf
+                            <div class="mb-3">
+                            <textarea name="body" rows="5"
+                                      class="form-control @error('body') is-invalid @enderror"
+                                      placeholder="{{ __('Write your reply...') }}" required>{{ old('body') }}</textarea>
+                                @error('body')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+                            <button type="submit" class="btn btn-primary">@lang('Post Reply')</button>
+                        </form>
+                    </div>
+                </div>
+            @else
+                <div class="alert alert-secondary mt-4">@lang('This thread is locked and no longer accepts replies.')</div>
+            @endif
+        @else
+            <div class="alert alert-light mt-4">
+                <a href="{{ route('login') }}">@lang('Log in')</a> @lang('to leave a reply.')
+            </div>
+        @endauth
+
+    </div>
+@endsection

--- a/resources/views/layouts/banner.blade.php
+++ b/resources/views/layouts/banner.blade.php
@@ -49,8 +49,8 @@
                         </a>
                     </li>
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <i class="fa-solid fa-language"></i> @lang('Other languages')
+                        <a class="nav-link dropdown-toggle d-flex align-items-center gap-1" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <i class="ph-fill ph-translate"></i> @lang('Other languages')
                         </a>
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
                             @foreach(LaravelLocalization::getSupportedLocales() as $localeCode => $properties)
@@ -72,7 +72,10 @@
                 </ul>
                 <ul class="navbar-nav justify-content-end">
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ URL::to('/resources') }}"><i class="fas fa-book"></i> @lang('Library')</a>
+                        <a class="nav-link d-flex align-items-center gap-1" href="{{ URL::to('/resources') }}"><i class="ph-fill ph-book"></i> @lang('Library')</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link d-flex align-items-center gap-1" href="{{ route('threads.index') }}"><i class="ph-fill ph-users-three"></i> @lang('Community')</a>
                     </li>
                     <li class="nav-item">
                         <a href="{{ route('storyweaver-confirm', ['landing_page' => 'storyweaver_default']) }}" class="nav-link" title="StoryWeaver">
@@ -84,12 +87,12 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ route('resource.form') }}"><i class="fas fa-upload"></i> @lang('Submit a resource')</a>
+                        <a class="nav-link d-flex align-items-center gap-1" href="{{ route('resource.form') }}"><i class="ph-fill ph-upload"></i> @lang('Submit a resource')</a>
                     </li>
                     @if (Auth::check())
-                        <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                <i class="fa-solid fa-circle-user fa-2xl"></i>
+                        <li class="nav-item dropdown user-icon">
+                            <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <i class="ph-fill ph-user-circle"></i>
                             </a>
                             <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                                 <a class="dropdown-item" href="{{ URL::to('/user/profile') }}" title="@lang('Account')">@lang('Account')</a>
@@ -102,7 +105,7 @@
                         </li>
                     @else
                         <li class="nav-item">
-                            <a href="{{ URL::to('/login') }}" class="btn btn-primary" title="@lang('Log in or Register')"><i class="fas fa-sign-in-alt"></i> @lang('Log in / Register')</a>
+                            <a href="{{ URL::to('/login') }}" class="btn btn-primary d-flex align-items-center gap-1" title="@lang('Log in or Register')"><i class="ph-fill ph-sign-in"></i> @lang('Log in / Register')</a>
                         </li>
                     @endif
                 </ul>

--- a/resources/views/layouts/search.blade.php
+++ b/resources/views/layouts/search.blade.php
@@ -6,8 +6,8 @@
         <div class="col-md-7 col-12 my-2">
             <div class="input-group">
                 <input type="text" id="search" name="search" class="form-control form-control-lg" placeholder="@lang('Search our growing library!')">
-                <button class="btn btn-primary btn-lg" type="submit">
-                    <i class="fas fa-search"></i>
+                <button class="btn btn-primary btn-lg d-flex align-items-center" type="submit">
+                    <i class="ph-light ph-magnifying-glass search-icons"></i>
                 </button>
                 @if(request()->routeIs('resourceList'))
                     <button class="btn btn-primary ms-1 d-flex align-items-center"
@@ -15,13 +15,13 @@
                             data-bs-toggle="offcanvas"
                             data-bs-target="#filterPanel"
                             title="@lang('Filter')">
-                        <i class="ph-fill ph-sliders filter-icon"></i>
+                        <i class="ph-fill ph-sliders search-icons"></i>
                     </button>
                 @else
                     <a href="{{ route('resourceList') }}#filterPanel"
                        class="btn btn-primary ms-1 d-flex align-items-center"
                        title="@lang('Filter')">
-                        <i class="ph-fill ph-sliders filter-icon"></i>
+                        <i class="ph-fill ph-sliders search-icons"></i>
                     </a>
                 @endif
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\DownloadController;
 use App\Http\Controllers\FileController;
 use App\Http\Controllers\FlagController;
 use App\Http\Controllers\Forum\CategoryController;
+use App\Http\Controllers\Forum\ForumUserController;
 use App\Http\Controllers\Forum\PostController;
 use App\Http\Controllers\Forum\ThreadController;
 use App\Http\Controllers\GlossaryAnalyticsController;
@@ -358,7 +359,6 @@ Route::prefix(LaravelLocalization::setLocale())->middleware('localeSessionRedire
 
         // Public
         Route::get('threads', [ThreadController::class, 'index'])->name('threads.index');
-        Route::get('threads/create', [ThreadController::class, 'create'])->name('threads.create');
         Route::get('threads/{thread}', [ThreadController::class, 'show'])->name('threads.show');
 
         // Admin only (must be before categories/{category})
@@ -376,13 +376,14 @@ Route::prefix(LaravelLocalization::setLocale())->middleware('localeSessionRedire
         // Auth required
         Route::middleware('auth')->group(function () {
             Route::post('threads', [ThreadController::class, 'store'])->name('threads.store');
+            Route::get('threads/create', [ThreadController::class, 'create'])->name('threads.create');
             Route::get('threads/{thread}/edit', [ThreadController::class, 'edit'])->name('threads.edit');
             Route::put('threads/{thread}', [ThreadController::class, 'update'])->name('threads.update');
             Route::delete('threads/{thread}', [ThreadController::class, 'destroy'])->name('threads.destroy');
 
             Route::post('threads/{thread}/posts', [PostController::class, 'store'])->name('threads.posts.store');
-            Route::put('posts/{post}', [PostController::class, 'update'])->name('posts.update');
-            Route::delete('posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
+            Route::put('threads/{thread}/posts/{post}', [PostController::class, 'update'])->name('threads.posts.update');
+            Route::delete('threads/{thread}/posts/{post}', [PostController::class, 'destroy'])->name('threads.posts.destroy');
         });
 
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -359,6 +359,7 @@ Route::prefix(LaravelLocalization::setLocale())->middleware('localeSessionRedire
 
         // Public
         Route::get('threads', [ThreadController::class, 'index'])->name('threads.index');
+        Route::get('threads/create', [ThreadController::class, 'create'])->name('threads.create')->middleware('auth');
         Route::get('threads/{thread}', [ThreadController::class, 'show'])->name('threads.show');
 
         // Admin only (must be before categories/{category})
@@ -376,7 +377,6 @@ Route::prefix(LaravelLocalization::setLocale())->middleware('localeSessionRedire
         // Auth required
         Route::middleware('auth')->group(function () {
             Route::post('threads', [ThreadController::class, 'store'])->name('threads.store');
-            Route::get('threads/create', [ThreadController::class, 'create'])->name('threads.create');
             Route::get('threads/{thread}/edit', [ThreadController::class, 'edit'])->name('threads.edit');
             Route::put('threads/{thread}', [ThreadController::class, 'update'])->name('threads.update');
             Route::delete('threads/{thread}', [ThreadController::class, 'destroy'])->name('threads.destroy');

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,9 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DownloadController;
 use App\Http\Controllers\FileController;
 use App\Http\Controllers\FlagController;
+use App\Http\Controllers\Forum\CategoryController;
+use App\Http\Controllers\Forum\PostController;
+use App\Http\Controllers\Forum\ThreadController;
 use App\Http\Controllers\GlossaryAnalyticsController;
 use App\Http\Controllers\GlossaryController;
 use App\Http\Controllers\GlossarySubjectController;
@@ -349,6 +352,39 @@ Route::prefix(LaravelLocalization::setLocale())->middleware('localeSessionRedire
         Route::get('privacy-policy', 'index')->name('privacy-policy');
         Route::get('mobile-privacy-policy', 'mobilePrivacyPolicy')->name('mobile-privacy-policy');
         Route::get('opt-out', 'optOut')->name('opt-out');
+    });
+
+    Route::prefix('forum')->group(function () {
+
+        // Public
+        Route::get('threads', [ThreadController::class, 'index'])->name('threads.index');
+        Route::get('threads/create', [ThreadController::class, 'create'])->name('threads.create');
+        Route::get('threads/{thread}', [ThreadController::class, 'show'])->name('threads.show');
+
+        // Admin only (must be before categories/{category})
+        Route::middleware(['auth', 'admin'])->group(function () {
+            Route::resource('categories', CategoryController::class)->except(['show']);
+            Route::patch('threads/{thread}/lock', [ThreadController::class, 'lock'])->name('threads.lock');
+            Route::patch('threads/{thread}/pin', [ThreadController::class, 'pin'])->name('threads.pin');
+            Route::patch('threads/{thread}/move', [ThreadController::class, 'move'])->name('threads.move');
+            Route::patch('users/{user}/ban', [ForumUserController::class, 'ban'])->name('forum.users.ban');
+        });
+
+        // Public category show (wildcard, must be last)
+        Route::get('categories/{category}', [CategoryController::class, 'show'])->name('threads.categories.show');
+
+        // Auth required
+        Route::middleware('auth')->group(function () {
+            Route::post('threads', [ThreadController::class, 'store'])->name('threads.store');
+            Route::get('threads/{thread}/edit', [ThreadController::class, 'edit'])->name('threads.edit');
+            Route::put('threads/{thread}', [ThreadController::class, 'update'])->name('threads.update');
+            Route::delete('threads/{thread}', [ThreadController::class, 'destroy'])->name('threads.destroy');
+
+            Route::post('threads/{thread}/posts', [PostController::class, 'store'])->name('threads.posts.store');
+            Route::put('posts/{post}', [PostController::class, 'update'])->name('posts.update');
+            Route::delete('posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
+        });
+
     });
 });
 

--- a/tests/Feature/Http/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/CommentControllerTest.php
@@ -150,6 +150,6 @@ class CommentControllerTest extends TestCase
 
         $response = $this->actingAs($user)->get("/en/admin/comments/published/{$comment->id}");
 
-        $response->assertStatus(302);
+        $response->assertStatus(403);
     }
 }

--- a/tests/Feature/Http/Controllers/DashboardControllerTest.php
+++ b/tests/Feature/Http/Controllers/DashboardControllerTest.php
@@ -68,7 +68,7 @@ class DashboardControllerTest extends TestCase
 
         $response = $this->actingAs($user)->get('en/admin');
 
-        $response->assertStatus(302);
+        $response->assertStatus(403);
     }
 
     public function test_dashboard_page_is_not_accessible_to_guests(): void

--- a/tests/Feature/Http/Controllers/DownloadControllerTest.php
+++ b/tests/Feature/Http/Controllers/DownloadControllerTest.php
@@ -50,6 +50,6 @@ class DownloadControllerTest extends TestCase
 
         $response = $this->actingAs($user)->get(url('en/admin/reports/downloads'));
 
-        $response->assertStatus(302);
+        $response->assertStatus(403);
     }
 }

--- a/tests/Feature/Http/Controllers/Forum/CategoryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Forum/CategoryControllerTest.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Forum;
+
+use App\Models\Category;
+use App\Models\Thread;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\Forum\CategoryController
+ */
+class CategoryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -------------------------------------------------------------------------
+    // index (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function index_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('en/forum/categories');
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function index_returns_view_for_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+
+        $response = $this->actingAs($admin)->get('en/forum/categories');
+
+        $response->assertOk();
+        $response->assertViewIs('forum.categories.index');
+    }
+
+    // -------------------------------------------------------------------------
+    // create (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function create_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('en/forum/categories/create');
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function create_returns_view_for_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+
+        $response = $this->actingAs($admin)->get('en/forum/categories/create');
+
+        $response->assertOk();
+        $response->assertViewIs('forum.categories.create');
+    }
+
+    // -------------------------------------------------------------------------
+    // store (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function store_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('en/forum/categories', [
+            'name' => 'Test Category',
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('categories', ['name' => 'Test Category']);
+    }
+
+    #[Test]
+    public function store_creates_category_and_redirects(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+
+        $response = $this->actingAs($admin)->post('en/forum/categories', [
+            'name'        => 'Test Category',
+            'description' => 'A test category description.',
+            'order'       => 1,
+            'is_private'  => false,
+        ]);
+
+        $response->assertRedirect(route('categories.index'));
+        $this->assertDatabaseHas('categories', ['name' => 'Test Category']);
+    }
+
+    #[Test]
+    public function store_validates_name_is_required(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+
+        $response = $this->actingAs($admin)->post('en/forum/categories', []);
+
+        $response->assertSessionHasErrors(['name']);
+    }
+
+    #[Test]
+    public function store_supports_parent_category(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $parent = Category::factory()->create();
+
+        $this->actingAs($admin)->post('en/forum/categories', [
+            'name'      => 'Child Category',
+            'parent_id' => $parent->id,
+        ]);
+
+        $this->assertDatabaseHas('categories', [
+            'name'      => 'Child Category',
+            'parent_id' => $parent->id,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // edit (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function edit_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->get("en/forum/categories/{$category->id}/edit");
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function edit_returns_view_for_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($admin)->get("en/forum/categories/{$category->id}/edit");
+
+        $response->assertOk();
+        $response->assertViewIs('forum.categories.edit');
+    }
+
+    // -------------------------------------------------------------------------
+    // update (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function update_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->put("en/forum/categories/{$category->id}", [
+            'name' => 'Updated Name',
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('categories', ['name' => 'Updated Name']);
+    }
+
+    #[Test]
+    public function update_updates_category_and_redirects(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($admin)->put("en/forum/categories/{$category->id}", [
+            'name'        => 'Updated Category Name',
+            'description' => 'Updated description.',
+            'order'       => 2,
+            'is_private'  => true,
+        ]);
+
+        $response->assertRedirect(route('categories.index'));
+        $this->assertDatabaseHas('categories', [
+            'id'         => $category->id,
+            'name'       => 'Updated Category Name',
+            'is_private' => true,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // destroy (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function destroy_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->delete("en/forum/categories/{$category->id}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('categories', ['id' => $category->id]);
+    }
+
+    #[Test]
+    public function destroy_deletes_category_and_redirects(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($admin)->delete("en/forum/categories/{$category->id}");
+
+        $response->assertRedirect(route('categories.index'));
+        $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+    }
+
+    // -------------------------------------------------------------------------
+    // show (public)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function show_returns_view_for_public_category(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $category = Category::factory()->create();
+
+        $response = $this->get("en/forum/categories/{$category->id}");
+
+        $response->assertOk();
+        $response->assertViewIs('forum.categories.show');
+    }
+
+    #[Test]
+    public function show_returns_403_for_private_category_when_guest(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $category = Category::factory()->private()->create();
+
+        $response = $this->get("en/forum/categories/{$category->id}");
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function show_returns_view_for_private_category_when_authenticated(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $category = Category::factory()->private()->create();
+
+        $response = $this->actingAs($user)->get("en/forum/categories/{$category->id}");
+
+        $response->assertOk();
+    }
+
+    #[Test]
+    public function show_lists_threads_in_category(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $category = Category::factory()->create();
+        $thread = Thread::factory()->create(['category_id' => $category->id]);
+
+        $response = $this->get("en/forum/categories/{$category->id}");
+
+        $response->assertOk();
+        $response->assertSee($thread->title);
+    }
+}

--- a/tests/Feature/Http/Controllers/Forum/ForumUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/Forum/ForumUserControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Forum;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\Forum\ForumUserController
+ */
+class ForumUserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function ban_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $actor = User::factory()->create();
+        $target = User::factory()->create();
+
+        $response = $this->actingAs($actor)->patch("en/forum/users/{$target->id}/ban");
+
+        $response->assertForbidden();
+        $this->assertNull($target->fresh()->forum_banned_at);
+    }
+
+    #[Test]
+    public function ban_bans_an_unbanned_user(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $target = User::factory()->create(['forum_banned_at' => null]);
+
+        $this->actingAs($admin)->patch("en/forum/users/{$target->id}/ban");
+
+        $this->assertNotNull($target->fresh()->forum_banned_at);
+    }
+
+    #[Test]
+    public function ban_unbans_a_banned_user(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $target = User::factory()->create(['forum_banned_at' => now()]);
+
+        $this->actingAs($admin)->patch("en/forum/users/{$target->id}/ban");
+
+        $this->assertNull($target->fresh()->forum_banned_at);
+    }
+
+    #[Test]
+    public function ban_redirects_back_with_success_alert(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $target = User::factory()->create(['forum_banned_at' => null]);
+
+        $response = $this->actingAs($admin)->patch("en/forum/users/{$target->id}/ban");
+
+        $response->assertRedirect();
+        $response->assertSessionHas('alert.level', 'success');
+    }
+}

--- a/tests/Feature/Http/Controllers/Forum/PostControllerTest.php
+++ b/tests/Feature/Http/Controllers/Forum/PostControllerTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Forum;
+
+use App\Models\Post;
+use App\Models\Thread;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\Forum\PostController
+ */
+class PostControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -------------------------------------------------------------------------
+    // store
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function store_redirects_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $thread = Thread::factory()->create();
+
+        $response = $this->post("en/forum/threads/{$thread->id}/posts", [
+            'body' => 'A valid reply body.',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('posts', ['thread_id' => $thread->id]);
+    }
+
+    #[Test]
+    public function store_creates_post_and_redirects(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create();
+
+        $response = $this->actingAs($user)->post("en/forum/threads/{$thread->id}/posts", [
+            'body' => 'A valid reply body.',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('posts', [
+            'thread_id' => $thread->id,
+            'user_id'   => $user->id,
+            'body'      => 'A valid reply body.',
+        ]);
+    }
+
+    #[Test]
+    public function store_updates_thread_last_post_at(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create(['last_post_at' => null]);
+
+        $this->actingAs($user)->post("en/forum/threads/{$thread->id}/posts", [
+            'body' => 'A valid reply body.',
+        ]);
+
+        $this->assertNotNull($thread->fresh()->last_post_at);
+    }
+
+    #[Test]
+    public function store_returns_403_on_locked_thread(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->locked()->create();
+
+        $response = $this->actingAs($user)->post("en/forum/threads/{$thread->id}/posts", [
+            'body' => 'A valid reply body.',
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('posts', ['thread_id' => $thread->id]);
+    }
+
+    #[Test]
+    public function store_returns_403_for_banned_users(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create(['forum_banned_at' => now()]);
+        $thread = Thread::factory()->create();
+
+        $response = $this->actingAs($user)->post("en/forum/threads/{$thread->id}/posts", [
+            'body' => 'A valid reply body.',
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('posts', ['thread_id' => $thread->id]);
+    }
+
+    #[Test]
+    public function store_validates_body_is_required(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create();
+
+        $response = $this->actingAs($user)->post("en/forum/threads/{$thread->id}/posts", []);
+
+        $response->assertSessionHasErrors(['body']);
+    }
+
+    // -------------------------------------------------------------------------
+    // update
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function update_redirects_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $post = Post::factory()->create();
+
+        $response = $this->put("en/forum/threads/{$post->thread_id}/posts/{$post->id}", [
+            'body' => 'Updated body content.',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('posts', ['body' => 'Updated body content.']);
+    }
+
+    #[Test]
+    public function update_allows_post_owner_to_update(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->put("en/forum/threads/{$post->thread_id}/posts/{$post->id}", [
+            'body' => 'Updated body content.',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('posts', [
+            'id'   => $post->id,
+            'body' => 'Updated body content.',
+        ]);
+    }
+
+    #[Test]
+    public function update_returns_403_for_non_owner(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->put("en/forum/threads/{$post->thread_id}/posts/{$post->id}", [
+            'body' => 'Hijacked body content.',
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('posts', ['body' => 'Hijacked body content.']);
+    }
+
+    #[Test]
+    public function update_allows_admin_to_update_any_post(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $post = Post::factory()->create();
+
+        $response = $this->actingAs($admin)->put("en/forum/threads/{$post->thread_id}/posts/{$post->id}", [
+            'body' => 'Admin updated body.',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('posts', [
+            'id'   => $post->id,
+            'body' => 'Admin updated body.',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // destroy
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function destroy_redirects_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $post = Post::factory()->create();
+
+        $response = $this->delete("en/forum/threads/{$post->thread_id}/posts/{$post->id}");
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('posts', ['id' => $post->id]);
+    }
+
+    #[Test]
+    public function destroy_allows_post_owner_to_delete(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->delete("en/forum/threads/{$post->thread_id}/posts/{$post->id}");
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('posts', ['id' => $post->id]);
+    }
+
+    #[Test]
+    public function destroy_returns_403_for_non_owner(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->delete("en/forum/threads/{$post->thread_id}/posts/{$post->id}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('posts', ['id' => $post->id]);
+    }
+
+    #[Test]
+    public function destroy_allows_admin_to_delete_any_post(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $post = Post::factory()->create();
+
+        $response = $this->actingAs($admin)->delete("en/forum/threads/{$post->thread_id}/posts/{$post->id}");
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('posts', ['id' => $post->id]);
+    }
+}

--- a/tests/Feature/Http/Controllers/Forum/ThreadControllerTest.php
+++ b/tests/Feature/Http/Controllers/Forum/ThreadControllerTest.php
@@ -1,0 +1,460 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Forum;
+
+use App\Models\Category;
+use App\Models\Thread;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @see \App\Http\Controllers\Forum\ThreadController
+ */
+class ThreadControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -------------------------------------------------------------------------
+    // index
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function index_returns_view_for_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        Thread::factory()->create();
+
+        $response = $this->get('en/forum/threads');
+
+        $response->assertOk();
+        $response->assertViewIs('forum.threads.index');
+    }
+
+    #[Test]
+    public function index_hides_private_category_threads_from_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $private = Category::factory()->private()->create();
+        $thread = Thread::factory()->create(['category_id' => $private->id]);
+
+        $response = $this->get('en/forum/threads');
+
+        $response->assertOk();
+        $response->assertDontSee($thread->title);
+    }
+
+    #[Test]
+    public function index_shows_private_category_threads_to_authenticated_users(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $private = Category::factory()->private()->create();
+        $thread = Thread::factory()->create(['category_id' => $private->id]);
+
+        $response = $this->actingAs($user)->get('en/forum/threads');
+
+        $response->assertOk();
+        $response->assertSee($thread->title);
+    }
+
+    // -------------------------------------------------------------------------
+    // create
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function create_redirects_guests_to_login(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $response = $this->get('en/forum/threads/create');
+
+        $response->assertRedirect();
+    }
+
+    #[Test]
+    public function create_returns_view_for_authenticated_users(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('en/forum/threads/create');
+
+        $response->assertOk();
+        $response->assertViewIs('forum.threads.create');
+    }
+
+    // -------------------------------------------------------------------------
+    // store
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function store_redirects_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $category = Category::factory()->create();
+
+        $response = $this->post('en/forum/threads', [
+            'title'       => 'A valid thread title',
+            'body'        => 'A valid body with enough content.',
+            'category_id' => $category->id,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('threads', ['title' => 'A valid thread title']);
+    }
+
+    #[Test]
+    public function store_creates_thread_and_redirects(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->post('en/forum/threads', [
+            'title'       => 'A valid thread title',
+            'body'        => 'A valid body with enough content.',
+            'category_id' => $category->id,
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('threads', [
+            'title'       => 'A valid thread title',
+            'user_id'     => $user->id,
+            'category_id' => $category->id,
+        ]);
+    }
+
+    #[Test]
+    public function store_returns_403_for_banned_users(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create(['forum_banned_at' => now()]);
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->post('en/forum/threads', [
+            'title'       => 'A valid thread title',
+            'body'        => 'A valid body with enough content.',
+            'category_id' => $category->id,
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('threads', ['user_id' => $user->id]);
+    }
+
+    #[Test]
+    public function store_validates_required_fields(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('en/forum/threads', []);
+
+        $response->assertSessionHasErrors(['title', 'body', 'category_id']);
+    }
+
+    #[Test]
+    public function store_validates_minimum_title_length(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->post('en/forum/threads', [
+            'title'       => 'Hi',
+            'body'        => 'A valid body with enough content.',
+            'category_id' => $category->id,
+        ]);
+
+        $response->assertSessionHasErrors(['title']);
+    }
+
+    #[Test]
+    public function store_validates_category_exists(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('en/forum/threads', [
+            'title'       => 'A valid thread title',
+            'body'        => 'A valid body with enough content.',
+            'category_id' => 99999,
+        ]);
+
+        $response->assertSessionHasErrors(['category_id']);
+    }
+
+    // -------------------------------------------------------------------------
+    // show
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function show_returns_view_for_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $thread = Thread::factory()->create();
+
+        $response = $this->get("en/forum/threads/{$thread->id}");
+
+        $response->assertOk();
+        $response->assertViewIs('forum.threads.show');
+    }
+
+    // -------------------------------------------------------------------------
+    // edit
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function edit_redirects_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $thread = Thread::factory()->create();
+
+        $response = $this->get("en/forum/threads/{$thread->id}/edit");
+
+        $response->assertRedirect();
+    }
+
+    #[Test]
+    public function edit_returns_view_for_thread_owner(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->get("en/forum/threads/{$thread->id}/edit");
+
+        $response->assertOk();
+        $response->assertViewIs('forum.threads.edit');
+    }
+
+    #[Test]
+    public function edit_returns_403_for_non_owner(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->get("en/forum/threads/{$thread->id}/edit");
+
+        $response->assertForbidden();
+    }
+
+    // -------------------------------------------------------------------------
+    // update
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function update_redirects_guests(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $thread = Thread::factory()->create();
+
+        $response = $this->put("en/forum/threads/{$thread->id}", [
+            'title'       => 'Updated title here',
+            'body'        => 'Updated body with enough content.',
+            'category_id' => $thread->category_id,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('threads', ['title' => 'Updated title here']);
+    }
+
+    #[Test]
+    public function update_allows_thread_owner_to_update(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->put("en/forum/threads/{$thread->id}", [
+            'title'       => 'Updated title here',
+            'body'        => 'Updated body with enough content.',
+            'category_id' => $thread->category_id,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('threads', [
+            'id'    => $thread->id,
+            'title' => 'Updated title here',
+        ]);
+    }
+
+    #[Test]
+    public function update_returns_403_for_non_owner(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->put("en/forum/threads/{$thread->id}", [
+            'title'       => 'Hijacked title',
+            'body'        => 'Updated body with enough content.',
+            'category_id' => $thread->category_id,
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('threads', ['title' => 'Hijacked title']);
+    }
+
+    // -------------------------------------------------------------------------
+    // destroy
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function destroy_allows_thread_owner_to_delete(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->delete("en/forum/threads/{$thread->id}");
+
+        $response->assertRedirect(route('threads.index'));
+        $this->assertDatabaseMissing('threads', ['id' => $thread->id]);
+    }
+
+    #[Test]
+    public function destroy_returns_403_for_non_owner(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $owner->id]);
+
+        $response = $this->actingAs($other)->delete("en/forum/threads/{$thread->id}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('threads', ['id' => $thread->id]);
+    }
+
+    // -------------------------------------------------------------------------
+    // lock (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function lock_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create();
+
+        $response = $this->actingAs($user)->patch("en/forum/threads/{$thread->id}/lock");
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function lock_toggles_thread_lock_status(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $thread = Thread::factory()->create(['is_locked' => false]);
+
+        $this->actingAs($admin)->patch("en/forum/threads/{$thread->id}/lock");
+
+        $this->assertTrue($thread->fresh()->is_locked);
+
+        $this->actingAs($admin)->patch("en/forum/threads/{$thread->id}/lock");
+
+        $this->assertFalse($thread->fresh()->is_locked);
+    }
+
+    // -------------------------------------------------------------------------
+    // pin (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function pin_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create();
+
+        $response = $this->actingAs($user)->patch("en/forum/threads/{$thread->id}/pin");
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function pin_toggles_thread_pin_status(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $thread = Thread::factory()->create(['is_pinned' => false]);
+
+        $this->actingAs($admin)->patch("en/forum/threads/{$thread->id}/pin");
+
+        $this->assertTrue($thread->fresh()->is_pinned);
+
+        $this->actingAs($admin)->patch("en/forum/threads/{$thread->id}/pin");
+
+        $this->assertFalse($thread->fresh()->is_pinned);
+    }
+
+    // -------------------------------------------------------------------------
+    // move (admin only)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function move_requires_admin(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create();
+        $newCategory = Category::factory()->create();
+
+        $response = $this->actingAs($user)->patch("en/forum/threads/{$thread->id}/move", [
+            'category_id' => $newCategory->id,
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    #[Test]
+    public function move_moves_thread_to_new_category(): void
+    {
+        $this->refreshApplicationWithLocale('en');
+
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $thread = Thread::factory()->create();
+        $newCategory = Category::factory()->create();
+
+        $this->actingAs($admin)->patch("en/forum/threads/{$thread->id}/move", [
+            'category_id' => $newCategory->id,
+        ]);
+
+        $this->assertEquals($newCategory->id, $thread->fresh()->category_id);
+    }
+}

--- a/tests/Feature/Http/Controllers/GlossarySubjectControllerTest.php
+++ b/tests/Feature/Http/Controllers/GlossarySubjectControllerTest.php
@@ -95,6 +95,6 @@ class GlossarySubjectControllerTest extends TestCase
 
         $response = $this->actingAs($user)->get(route('glossary_subjects_list'));
 
-        $response->assertRedirect('/home');
+        $response->assertForbidden();
     }
 }

--- a/tests/Unit/Forum/ForumModelTest.php
+++ b/tests/Unit/Forum/ForumModelTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Unit\Forum;
+
+use App\Models\Category;
+use App\Models\Post;
+use App\Models\Thread;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ForumModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -------------------------------------------------------------------------
+    // User
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function user_is_forum_banned_when_forum_banned_at_is_set(): void
+    {
+        $user = User::factory()->create(['forum_banned_at' => now()]);
+
+        $this->assertTrue($user->isForumBanned());
+    }
+
+    #[Test]
+    public function user_is_not_forum_banned_when_forum_banned_at_is_null(): void
+    {
+        $user = User::factory()->create(['forum_banned_at' => null]);
+
+        $this->assertFalse($user->isForumBanned());
+    }
+
+    #[Test]
+    public function user_has_many_threads(): void
+    {
+        $user = User::factory()->create();
+        Thread::factory()->count(3)->create(['user_id' => $user->id]);
+
+        $this->assertCount(3, $user->threads);
+    }
+
+    // -------------------------------------------------------------------------
+    // Thread
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function thread_generates_slug_from_title(): void
+    {
+        $thread = Thread::factory()->create(['title' => 'My Test Thread Title']);
+
+        $this->assertNotNull($thread->slug);
+        $this->assertStringContainsString('my-test-thread-title', $thread->slug);
+    }
+
+    #[Test]
+    public function thread_belongs_to_user(): void
+    {
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $user->id]);
+
+        $this->assertEquals($user->id, $thread->user->id);
+    }
+
+    #[Test]
+    public function thread_belongs_to_category(): void
+    {
+        $category = Category::factory()->create();
+        $thread = Thread::factory()->create(['category_id' => $category->id]);
+
+        $this->assertEquals($category->id, $thread->category->id);
+    }
+
+    #[Test]
+    public function thread_has_many_posts(): void
+    {
+        $thread = Thread::factory()->create();
+        Post::factory()->count(3)->create(['thread_id' => $thread->id]);
+
+        $this->assertCount(3, $thread->posts);
+    }
+
+    #[Test]
+    public function thread_has_one_latest_post(): void
+    {
+        $thread = Thread::factory()->create();
+        Post::factory()->count(3)->create(['thread_id' => $thread->id]);
+        $latest = Post::factory()->create(['thread_id' => $thread->id]);
+
+        $this->assertEquals($latest->id, $thread->latestPost->id);
+    }
+
+    // -------------------------------------------------------------------------
+    // Post
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function post_belongs_to_thread(): void
+    {
+        $thread = Thread::factory()->create();
+        $post = Post::factory()->create(['thread_id' => $thread->id]);
+
+        $this->assertEquals($thread->id, $post->thread->id);
+    }
+
+    #[Test]
+    public function post_belongs_to_user(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        $this->assertEquals($user->id, $post->user->id);
+    }
+
+    #[Test]
+    public function creating_post_updates_thread_last_post_at(): void
+    {
+        $thread = Thread::factory()->create(['last_post_at' => null]);
+
+        Post::factory()->create(['thread_id' => $thread->id]);
+
+        $this->assertNotNull($thread->fresh()->last_post_at);
+    }
+
+    // -------------------------------------------------------------------------
+    // Category
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function category_generates_slug_from_name(): void
+    {
+        $category = Category::factory()->create(['name' => 'My Category Name']);
+
+        $this->assertNotNull($category->slug);
+        $this->assertStringContainsString('my-category-name', $category->slug);
+    }
+
+    #[Test]
+    public function category_has_many_threads(): void
+    {
+        $category = Category::factory()->create();
+        Thread::factory()->count(2)->create(['category_id' => $category->id]);
+
+        $this->assertCount(2, $category->threads);
+    }
+
+    #[Test]
+    public function category_supports_parent_child_relationship(): void
+    {
+        $parent = Category::factory()->create();
+        $child = Category::factory()->create(['parent_id' => $parent->id]);
+
+        $this->assertEquals($parent->id, $child->parent->id);
+        $this->assertTrue($parent->children->contains($child));
+    }
+}

--- a/tests/Unit/Forum/PostPolicyTest.php
+++ b/tests/Unit/Forum/PostPolicyTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Forum;
+
+use App\Models\Post;
+use App\Models\User;
+use App\Policies\PostPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PostPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PostPolicy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->policy = new PostPolicy();
+    }
+
+    #[Test]
+    public function owner_can_update_their_post(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user);
+
+        $this->assertTrue($this->policy->update($user, $post));
+    }
+
+    #[Test]
+    public function admin_can_update_any_post(): void
+    {
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $post = Post::factory()->create();
+
+        $this->actingAs($admin);
+
+        $this->assertTrue($this->policy->update($admin, $post));
+    }
+
+    #[Test]
+    public function non_owner_cannot_update_post(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $owner->id]);
+
+        $this->actingAs($other);
+
+        $this->assertFalse($this->policy->update($other, $post));
+    }
+
+    #[Test]
+    public function owner_can_delete_their_post(): void
+    {
+        $user = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user);
+
+        $this->assertTrue($this->policy->delete($user, $post));
+    }
+
+    #[Test]
+    public function admin_can_delete_any_post(): void
+    {
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $post = Post::factory()->create();
+
+        $this->actingAs($admin);
+
+        $this->assertTrue($this->policy->delete($admin, $post));
+    }
+
+    #[Test]
+    public function non_owner_cannot_delete_post(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $owner->id]);
+
+        $this->actingAs($other);
+
+        $this->assertFalse($this->policy->delete($other, $post));
+    }
+}

--- a/tests/Unit/Forum/ThreadPolicyTest.php
+++ b/tests/Unit/Forum/ThreadPolicyTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Unit\Forum;
+
+use App\Models\Thread;
+use App\Models\User;
+use App\Policies\ThreadPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ThreadPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ThreadPolicy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->policy = new ThreadPolicy();
+    }
+
+    #[Test]
+    public function owner_can_update_their_thread(): void
+    {
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user);
+
+        $this->assertTrue($this->policy->update($user, $thread));
+    }
+
+    #[Test]
+    public function admin_can_update_any_thread(): void
+    {
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $thread = Thread::factory()->create();
+
+        $this->actingAs($admin);
+
+        $this->assertTrue($this->policy->update($admin, $thread));
+    }
+
+    #[Test]
+    public function non_owner_cannot_update_thread(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $owner->id]);
+
+        $this->actingAs($other);
+
+        $this->assertFalse($this->policy->update($other, $thread));
+    }
+
+    #[Test]
+    public function owner_can_delete_their_thread(): void
+    {
+        $user = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user);
+
+        $this->assertTrue($this->policy->delete($user, $thread));
+    }
+
+    #[Test]
+    public function admin_can_delete_any_thread(): void
+    {
+        $admin = User::factory()->create();
+        $admin->roles()->attach(5);
+        $thread = Thread::factory()->create();
+
+        $this->actingAs($admin);
+
+        $this->assertTrue($this->policy->delete($admin, $thread));
+    }
+
+    #[Test]
+    public function non_owner_cannot_delete_thread(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $thread = Thread::factory()->create(['user_id' => $owner->id]);
+
+        $this->actingAs($other);
+
+        $this->assertFalse($this->policy->delete($other, $thread));
+    }
+}


### PR DESCRIPTION
This PR adds a threaded discussion forum to the platform with categories, posts, and moderation tools.

Features
- Browse, create, and reply to threads organized by category
- Admin controls: lock/unlock, pin/unpin, move, and delete threads
- Forum-scoped user banning
- Private categories (authenticated users only)
- Slug-based thread URLs via spatie/laravel-sluggable

Models: `Thread`, `Post`, `Category`
Policies: `ThreadPolicy`, `PostPolicy`